### PR TITLE
feat(codex): add agentic SDLC plugin

### DIFF
--- a/.agents/agents/sdlc_intake/agent.md
+++ b/.agents/agents/sdlc_intake/agent.md
@@ -3,6 +3,7 @@ name: sdlc_intake
 description: Acts as a product manager. Distills user requirements into formal Product Requirement Documents (PRDs) and writes them to the specs/<feature-name>/ directory.
 tools:
   - view_file
+  - grep_search
   - invoke_subagent
   - send_message
   - ask_question
@@ -21,8 +22,8 @@ You are the Intake Agent (`sdlc_intake`) for the AIO-Agentic-SDLC framework. You
 
 ## CORE RESPONSIBILITIES
 
-1. **Gather Requirements**: Use the `ask_question` tool to interactively interview the user (similar to a /grill-me session) and clarify underspecified requirements. You MUST enforce a strict checklist of mandatory fields (Goal, Target Audience, Key Features, Constraints) before proceeding. Do not proceed until all fields are clearly defined.
-2. **Deduplication**: You MUST use the semantic search MCP/CLI tools to scan `specs/` for duplicate or overlapping PRDs based on a high similarity threshold. If an overlap exists, you MUST pause and ask the user for explicit confirmation before proceeding.
+1. **Gather Requirements**: Read candidate requests from `inbox/` when present. Use the `ask_question` tool to interactively interview the user (similar to a /grill-me session) and clarify underspecified requirements. You MUST enforce a strict checklist of mandatory fields (Goal, Target Audience, Key Features, Constraints) before proceeding. Do not proceed until all fields are clearly defined.
+2. **Deduplication**: You MUST use the semantic search MCP/CLI tools to scan `inbox/`, `specs/`, and `archive/` for duplicate or overlapping PRDs based on a high similarity threshold. If an overlap exists, you MUST pause and ask the user for explicit confirmation before proceeding.
 3. **Viability Research ("Should we do this?")**: Before finalizing the PRD, you MUST invoke the `sdlc_researcher` subagent to conduct a viability analysis (market research, dependency viability, product-market fit, complexity).
 4. **Document Generation**: Formulate a formal Product Requirement Document (PRD) formatted in Markdown with YAML frontmatter.
    - You MUST include all sections required by the `prd-template.md` (e.g., Dependencies, Non-Functional Requirements, Out of Scope, Viability Research).

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "personal",
+  "interface": {
+    "displayName": "Personal"
+  },
+  "plugins": [
+    {
+      "name": "aio-agentic-sdlc",
+      "source": {
+        "source": "local",
+        "path": "./plugins/aio-agentic-sdlc"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    }
+  ]
+}

--- a/.codex/agents/sdlc_architect.toml
+++ b/.codex/agents/sdlc_architect.toml
@@ -1,0 +1,8 @@
+name = "sdlc_architect"
+description = "Turn accepted requirements into researched dependency nodes and just-in-time specs."
+developer_instructions = """
+Act as the AIO Agentic SDLC technical architect. Do not implement production code.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/architect.md plus references/safeguards.md.
+Ground decisions in accepted requirements and fresh evidence. Use framework tools for Intention DAG nodes and generated micro-specs; never edit protected state manually.
+Return node identifiers, artifact paths, dependency decisions, and blockers.
+"""

--- a/.codex/agents/sdlc_cartographer.toml
+++ b/.codex/agents/sdlc_cartographer.toml
@@ -1,0 +1,8 @@
+name = "sdlc_cartographer"
+description = "Generate the Reality DAG, validate traceability, classify drift, and promote specs."
+developer_instructions = """
+Act as the AIO Agentic SDLC state cartographer.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md plus references/safeguards.md.
+Use MCP or CLI tooling for Reality DAG generation, traceability checks, and spec promotion. Never patch DAG files, graph edges, or generated metadata manually.
+Return affected GUIDs and paths, drift classification, and tool results.
+"""

--- a/.codex/agents/sdlc_devops.toml
+++ b/.codex/agents/sdlc_devops.toml
@@ -1,0 +1,8 @@
+name = "sdlc_devops"
+description = "Perform authorized branch, selective staging, commit, push, and pull-request work."
+developer_instructions = """
+Act as the AIO Agentic SDLC delivery and VCS specialist.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/devops.md plus references/safeguards.md.
+Inspect status and diffs, stage explicit paths, exclude runtime state and secrets, and use conventional branches and commits. Push, open pull requests, or mutate external systems only when the user authorized it.
+Return branch, staged paths, commits, remote actions, and blockers.
+"""

--- a/.codex/agents/sdlc_implementer.toml
+++ b/.codex/agents/sdlc_implementer.toml
@@ -1,0 +1,8 @@
+name = "sdlc_implementer"
+description = "Implement one accepted micro-spec with test-driven, minimal code changes."
+developer_instructions = """
+Act as the AIO Agentic SDLC implementer for one exact micro-spec.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/implementer.md plus references/safeguards.md.
+Use red-green-refactor, preserve GUID traceability, minimize blast radius, and update task state only through framework tools. Record a precise blocker rather than improvising around a contradictory spec.
+Return modified files, commands, exit codes, and residual risks.
+"""

--- a/.codex/agents/sdlc_intake.toml
+++ b/.codex/agents/sdlc_intake.toml
@@ -1,0 +1,8 @@
+name = "sdlc_intake"
+description = "Interview for requirements, detect overlap, research viability, and generate PRDs."
+developer_instructions = """
+Act as the AIO Agentic SDLC product intake specialist. Do not implement code or mutate DAG state.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/intake.md plus references/safeguards.md.
+Clarify material requirement gaps, check duplicate or overlapping PRDs, obtain confirmation for overlaps, and use framework tools for generated documents and metadata.
+Return the PRD path, decisions, duplicate-check result, and unresolved questions.
+"""

--- a/.codex/agents/sdlc_linter.toml
+++ b/.codex/agents/sdlc_linter.toml
@@ -1,0 +1,8 @@
+name = "sdlc_linter"
+description = "Run configured formatting, linting, type, complexity, and static-security checks."
+developer_instructions = """
+Act as the AIO Agentic SDLC static-quality specialist.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/linter.md plus references/safeguards.md.
+Discover repository-configured checks, run read-only checks first, limit safe auto-fixes to authorized files, and route semantic problems to the implementer.
+Return a compact pass/fail matrix, auto-fixes, and remaining diagnostics.
+"""

--- a/.codex/agents/sdlc_orchestrator.toml
+++ b/.codex/agents/sdlc_orchestrator.toml
@@ -1,0 +1,8 @@
+name = "sdlc_orchestrator"
+description = "Coordinate the complete AIO Agentic SDLC pipeline and its specialist agents."
+developer_instructions = """
+Own pipeline sequencing, protected-state transitions, feedback loops, and final synthesis.
+Before acting, read AGENTS.md, the manage-sdlc skill, references/roles/orchestrator.md, and references/safeguards.md under plugins/aio-agentic-sdlc/skills/manage-sdlc.
+Delegate bounded work to the matching sdlc_* custom agents when useful and allowed. Serialize DAG and backlog mutations, route QA failures back to implementation, and keep external writes within user authorization.
+Return artifact paths, state changes, validation evidence, and blockers.
+"""

--- a/.codex/agents/sdlc_qa.toml
+++ b/.codex/agents/sdlc_qa.toml
@@ -1,0 +1,8 @@
+name = "sdlc_qa"
+description = "Falsify implementation claims through requirements, runtime, static, and adversarial QA."
+developer_instructions = """
+Act as the AIO Agentic SDLC QA specialist. Do not modify production code or protected state.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/qa.md plus references/safeguards.md.
+Select checks proportionate to the change, use .qa-sandbox for scratch work, and verify micro-spec, parent intent, blast radius, traceability, runtime behavior, and relevant quality or security properties.
+Return PASS or FAIL with evidence, severity-ordered findings, and reproduction steps.
+"""

--- a/.codex/agents/sdlc_researcher.toml
+++ b/.codex/agents/sdlc_researcher.toml
@@ -1,0 +1,8 @@
+name = "sdlc_researcher"
+description = "Research product or technical decisions using current primary evidence."
+developer_instructions = """
+Act as the AIO Agentic SDLC researcher and data curator.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/researcher.md plus references/safeguards.md.
+Define the decision and criteria, prefer official or primary sources, cite evidence, distinguish facts from inferences, and generate a framework research artifact when required.
+Return the artifact path and a terse decision status to the invoking agent.
+"""

--- a/.codex/agents/sdlc_scribe.toml
+++ b/.codex/agents/sdlc_scribe.toml
@@ -1,0 +1,8 @@
+name = "sdlc_scribe"
+description = "Align user-facing documentation with accepted, verified repository behavior."
+developer_instructions = """
+Act as the AIO Agentic SDLC documentation scribe. Do not modify source code or protected state.
+Before acting, read AGENTS.md and plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/scribe.md plus references/safeguards.md.
+Base documentation on promoted specs, the final diff, and verified behavior. Update only relevant user-facing docs and validate changed Markdown.
+Return changed documentation paths and validation results.
+"""

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ venv.bak/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
+.uv-cache/
 .coverage
 htmlcov/
 .tox/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Repository guidance
+
+## Environment
+
+- Use UV for Python dependency management and command execution.
+- Create the development environment with `uv sync --frozen --group dev`.
+- Run tests with `uv run --no-sync pytest` after the environment is synchronized.
+
+## State integrity
+
+- Never edit `intention-dag.yaml`, `reality-dag.yaml`, or backlog state manually.
+- Use the `aio-agentic-sdlc` MCP tools, CLI, or Python API for every state transition.
+- Preserve canonical GUID traceability across DAG nodes, specs, and source markers.
+- Generate and promote framework documents through the provided tools; do not hand-edit
+  generated frontmatter.
+
+## Engineering workflow
+
+- Work on a feature branch, use test-driven development, and minimize the blast radius.
+- Use Conventional Commits when the user asks for a commit.
+- Inspect status and diffs before staging; never use blind staging commands.
+- Do not push, open pull requests, or mutate external trackers unless the user authorizes it.
+- Lint changed Markdown with Markdownlint when it is available.
+
+## Codex plugin
+
+- The distributable Codex plugin lives under `plugins/aio-agentic-sdlc/`.
+- The repo-scoped marketplace is `.agents/plugins/marketplace.json`.
+- Project-scoped named agents live under `.codex/agents/` and adapt the legacy Antigravity roles.
+- Validate plugin changes with the plugin and skill validators documented in
+  `doc/codex-plugin.md`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ This project is intended for **Personal / Non-Commercial Use Only**. When you pu
 
 Because `aio-agentic-sdlc` is an agentic-first toolkit, the easiest way to install and integrate the MCP Server into your IDE (VS Code, Cursor, Windsurf, Claude Desktop) is by using `uvx` to fetch the server directly from GitHub. This requires **zero local installation**.
 
+### Codex plugin
+
+Codex users can install the repository-scoped plugin from `.agents/plugins/marketplace.json`. It
+packages the `manage-sdlc` workflow skill and starts this project's MCP server through UV. See the
+[Codex plugin guide](doc/codex-plugin.md) for the architecture, local installation, migration map,
+and validation commands.
+
 Add the following to your IDE's `mcp.json` or equivalent configuration file:
 
 ```json
@@ -29,7 +36,7 @@ Add the following to your IDE's `mcp.json` or equivalent configuration file:
     "command": "uvx",
     "args": [
       "--from",
-      "git+https://github.com/aegolius-labs/aio-agentic-sdlc-cli",
+      "git+https://github.com/aegolius-labs/aio-agentic-sdlc",
       "aio-agentic-sdlc-mcp"
     ]
   }
@@ -41,7 +48,7 @@ Add the following to your IDE's `mcp.json` or equivalent configuration file:
 If you plan to use the CLI frequently and prefer not to type the full `uvx` GitHub URL every time, you can permanently install the CLI globally using `uv`:
 
 ```bash
-uv tool install git+https://github.com/aegolius-labs/aio-agentic-sdlc-cli
+uv tool install git+https://github.com/aegolius-labs/aio-agentic-sdlc
 ```
 
 Once installed, you can invoke the CLI natively:
@@ -60,8 +67,8 @@ agb export
 If you prefer not to install the CLI globally, you can execute commands entirely on-the-fly directly from GitHub:
 
 ```bash
-uvx --from git+https://github.com/aegolius-labs/aio-agentic-sdlc-cli agb init
-uvx --from git+https://github.com/aegolius-labs/aio-agentic-sdlc-cli agb export
+uvx --from git+https://github.com/aegolius-labs/aio-agentic-sdlc agb init
+uvx --from git+https://github.com/aegolius-labs/aio-agentic-sdlc agb export
 ```
 
 ## Spec-Driven Development (SDD)

--- a/doc/codex-plugin.md
+++ b/doc/codex-plugin.md
@@ -1,0 +1,101 @@
+# Codex plugin
+
+The repository includes a Codex plugin under `plugins/aio-agentic-sdlc/` and a repo-scoped
+marketplace at `.agents/plugins/marketplace.json`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    User["User in Codex"] --> Skill["manage-sdlc skill"]
+    Guidance["Repository AGENTS.md"] --> Skill
+    Skill --> Roles["Role references"]
+    Custom["Project .codex/agents"] --> Codex["Codex main agent and named subagents"]
+    Skill --> MCP["AIO Agentic SDLC MCP server"]
+    Roles --> Codex
+    MCP --> Engine["Python backlog, templates, and DAG engine"]
+    Codex --> Repo["Source, tests, and documentation"]
+    Engine --> State["Backlog, Intention DAG, Reality DAG, and specs"]
+```
+
+The plugin separates concerns as follows:
+
+| Existing Antigravity surface | Codex surface | Migration behavior |
+| --- | --- | --- |
+| `.agents/agents/*/agent.md` | `.codex/agents/*.toml` | Direct project-scoped named-agent mapping |
+| Agent prompt bodies | Skill role references | Portable fallback loaded only when a workflow needs that role |
+| `.agents/workflows/sdlc-pipeline.md` | `manage-sdlc` pipeline reference | Routes intake, architecture, implementation, QA, and delivery |
+| `.agents/rules/*.md` | Root `AGENTS.md` and skill safeguards | Applies durable repository invariants and task-specific constraints |
+| `ask_question` | Codex question UI or direct questions | Uses the available host interaction mechanism |
+| `invoke_subagent` | Codex multi-agent support | Used only when available, allowed, and useful for bounded work |
+| Antigravity tool names | MCP operation names | Matched by operation rather than provider-specific prefixes |
+| Python CLI | UV commands | Remains a fallback and local development interface |
+
+## Install for local testing
+
+Prerequisites are Git, UV, network access to GitHub, and a Codex surface that supports plugins.
+
+1. Open the repository as the active Codex project.
+2. Restart the desktop app so it discovers `.agents/plugins/marketplace.json` and the custom
+   agents under `.codex/agents/`.
+3. Open **Plugins**, select the **Personal** marketplace, and install **AIO Agentic SDLC**.
+4. Start a new task so Codex loads the plugin skill and MCP tools.
+
+To track this repo marketplace explicitly from the CLI, run:
+
+```powershell
+codex plugin marketplace add .
+codex plugin add aio-agentic-sdlc@personal
+```
+
+The plugin starts the MCP server with:
+
+```powershell
+uvx --from git+https://github.com/aegolius-labs/aio-agentic-sdlc aio-agentic-sdlc-mcp
+```
+
+The first start downloads the Python dependency set and can take longer than subsequent starts.
+The plugin grants a 120-second MCP startup window for this reason.
+
+## Use
+
+The skill can trigger implicitly, or it can be selected explicitly as `manage-sdlc`. Representative
+prompts include:
+
+- “Turn this feature idea into a traceable PRD.”
+- “Run this change through the agentic SDLC pipeline.”
+- “Show me the highest-priority unblocked task.”
+- “Generate the Reality DAG and report traceability drift.”
+
+For MCP calls, pass the absolute target repository as `project_path`. This is especially important
+when the plugin is installed because Codex runs the server from a cached plugin package, not from
+the target repository.
+
+## Validate changes
+
+From the repository root:
+
+```powershell
+uv sync --frozen --group dev
+uv run --no-sync pytest tests/test_codex_plugin.py tests/test_mcp_server.py tests/test_mcp_adversarial.py
+python C:\Users\Felix\.codex\skills\.system\skill-creator\scripts\quick_validate.py plugins\aio-agentic-sdlc\skills\manage-sdlc
+python C:\Users\Felix\.codex\skills\.system\plugin-creator\scripts\validate_plugin.py plugins\aio-agentic-sdlc
+```
+
+The validator paths above refer to the built-in authoring skills on Windows. On another machine,
+invoke the equivalent bundled `skill-creator` and `plugin-creator` scripts from that Codex install.
+
+## Current boundaries
+
+- Codex custom agents are project configuration, not a documented plugin component. This repo maps
+  all ten legacy roles to `.codex/agents/*.toml`; when the plugin is installed in another repo, its
+  skill can still delegate the bundled role playbooks to generic subagents.
+- Multi-agent execution depends on the Codex surface, policy, and task. The workflow remains usable
+  by one agent when delegation is unavailable.
+- Local plugins are copied into a Codex cache. Restart or reinstall the plugin and start a new task
+  after changing its bundled files.
+- The development MCP launcher follows the repository's default Git branch. Pin it to a release tag
+  when publishing a stable plugin version.
+- The current dependency graph includes a large semantic-search stack, so first-time MCP setup is
+  heavier than the backlog operations alone require. Splitting semantic deduplication into an
+  optional extra is a useful follow-up optimization.

--- a/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
+++ b/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "aio-agentic-sdlc",
+  "version": "0.21.0",
+  "description": "Run a traceable, dual-DAG software delivery workflow with Codex and the AIO Agentic SDLC MCP tools.",
+  "author": {
+    "name": "aegolius-labs",
+    "url": "https://github.com/aegolius-labs"
+  },
+  "homepage": "https://github.com/aegolius-labs/aio-agentic-sdlc",
+  "repository": "https://github.com/aegolius-labs/aio-agentic-sdlc",
+  "license": "PolyForm-Noncommercial-1.0.0",
+  "keywords": [
+    "agentic-sdlc",
+    "backlog",
+    "dual-dag",
+    "mcp",
+    "spec-driven-development"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "AIO Agentic SDLC",
+    "shortDescription": "Traceable dual-DAG planning and delivery",
+    "longDescription": "Plan requirements, prioritize graph-backed work, orchestrate implementation and QA, and reconcile intention with repository reality.",
+    "developerName": "aegolius-labs",
+    "category": "Engineering",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/aegolius-labs/aio-agentic-sdlc",
+    "defaultPrompt": [
+      "Turn this feature idea into a traceable PRD.",
+      "Run this change through the agentic SDLC pipeline.",
+      "Show me the highest-priority unblocked task."
+    ]
+  }
+}

--- a/plugins/aio-agentic-sdlc/.mcp.json
+++ b/plugins/aio-agentic-sdlc/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "aio-agentic-sdlc": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/aegolius-labs/aio-agentic-sdlc",
+        "aio-agentic-sdlc-mcp"
+      ],
+      "startup_timeout_sec": 120,
+      "tool_timeout_sec": 300
+    }
+  }
+}

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/SKILL.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: manage-sdlc
+description: Manage spec-driven software delivery with the AIO Agentic SDLC dual-DAG backlog and MCP tools. Use when Codex needs to interview for a PRD, detect duplicate requirements, plan or execute a feature through architect/implementer/QA roles, prioritize or update the agentic backlog, generate or reconcile intention and reality DAGs, validate GUID traceability, promote accepted specs, or prepare documentation and delivery.
+---
+
+# Manage AIO Agentic SDLC
+
+Use deterministic MCP tools for state and artifacts. Use Codex reasoning for requirements,
+architecture, implementation, review, and coordination.
+
+## Select the workflow
+
+- For feature ideation, discovery, or PRD work, read
+  [references/roles/intake.md](references/roles/intake.md) and the researcher role it links to.
+- For implementation, bug fixes, or end-to-end delivery, read
+  [references/pipeline.md](references/pipeline.md) and
+  [references/roles/orchestrator.md](references/roles/orchestrator.md).
+- For a direct backlog, DAG, traceability, document-generation, or promotion request, read
+  [references/tools.md](references/tools.md) and perform only that operation.
+- For role-specific work delegated by an orchestrator, read only the matching file under
+  `references/roles/` plus [references/safeguards.md](references/safeguards.md).
+
+## Initialize context
+
+1. Resolve the repository root to an absolute path.
+2. Read the applicable `AGENTS.md` chain and the requested PRD or task artifact.
+3. Inspect `intention-dag.yaml`, `reality-dag.yaml`, and runtime backlog state only as needed.
+4. Pass the absolute repository root as `project_path` to every MCP tool that accepts it.
+5. Prefer plugin MCP tools. If unavailable, use the local UV environment with `uv run`.
+   Use the portable `uvx --from git+https://github.com/aegolius-labs/aio-agentic-sdlc`
+   form only when the local checkout is not the intended implementation.
+
+## Coordinate roles
+
+- Keep one main agent responsible for state transitions and the final answer.
+- Delegate only bounded, independent work when subagents are available and delegation is allowed.
+  Prefer the matching project-scoped `sdlc_*` custom agent when it exists; otherwise give a
+  generic subagent the matching role reference.
+- Give each subagent the absolute repository path, exact artifact path, role reference,
+  allowed files/actions, and expected return shape.
+- Do not let multiple agents mutate the same files or DAG state concurrently.
+- Run implementation and QA as a feedback loop until QA passes or a genuine blocker is recorded.
+- Keep commits, pushes, pull requests, issue changes, and other external writes within the user's
+  explicit authorization.
+
+## Enforce invariants
+
+- Never edit `intention-dag.yaml`, `reality-dag.yaml`, or backlog state by hand. Use MCP, CLI,
+  or the Python API.
+- Never manually alter generated document frontmatter or promote a spec with filesystem moves.
+- Preserve canonical GUID traceability across DAG nodes, specifications, and source markers.
+- Use UV for Python environment and command execution.
+- Work test-first for implementation changes and run proportionate validation before completion.
+- Follow [references/safeguards.md](references/safeguards.md) for blocking and delivery rules.
+
+## Return results
+
+State the outcome first. Include changed artifact paths, DAG/backlog transitions, validation
+commands and results, and any unresolved blocker. Avoid dumping subagent transcripts.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/agents/openai.yaml
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/agents/openai.yaml
@@ -1,0 +1,14 @@
+interface:
+  display_name: "AIO Agentic SDLC"
+  short_description: "Plan and execute a traceable agentic SDLC"
+  default_prompt: "Use $manage-sdlc to plan and execute this change through the dual-DAG workflow."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "aio-agentic-sdlc"
+      description: "Deterministic backlog, document, DAG, and traceability tools"
+      transport: "stdio"
+
+policy:
+  allow_implicit_invocation: true

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
@@ -1,0 +1,42 @@
+# Delivery pipeline
+
+## 1. Intake
+
+Identify the authoritative input: direct prompt, `inbox/`, `changes/`, `specs/`, or the agentic
+backlog. For new requirements, follow [roles/intake.md](roles/intake.md). Do not invent missing
+product decisions when they would materially change scope.
+
+## 2. Architecture and planning
+
+Follow [roles/architect.md](roles/architect.md). Ground the breakdown in the accepted PRD and fresh
+research. Create structural dependency nodes before detailed just-in-time task specs. Use the
+framework tools for documents and DAG state.
+
+## 3. Reality reconciliation
+
+Follow [roles/cartographer.md](roles/cartographer.md). Generate the Reality DAG, validate GUID
+traceability, classify drift, and route the repair:
+
+- Reality drift: accepted intent is not implemented; route to the implementer.
+- Intention drift: code exists without accepted intent; route to the architect for validation.
+- Tooling drift: the framework cannot represent or detect the state; record a framework blocker.
+
+## 4. Implementation
+
+Pull the highest-priority unblocked node with the MCP tool. Follow
+[roles/implementer.md](roles/implementer.md) using the exact micro-spec and a red-green-refactor
+loop. Make the smallest coherent change.
+
+## 5. Static and runtime validation
+
+Run [roles/linter.md](roles/linter.md), then [roles/qa.md](roles/qa.md). Route actionable failures
+back to implementation and repeat. Do not promote a spec while validation is failing.
+
+## 6. Acceptance and delivery
+
+After QA passes:
+
+1. Have the cartographer promote the accepted spec with the MCP tool.
+2. Follow [roles/scribe.md](roles/scribe.md) for user-facing documentation.
+3. Follow [roles/devops.md](roles/devops.md) only for VCS actions authorized by the user.
+4. Report artifacts, state transitions, and validation evidence.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/architect.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/architect.md
@@ -1,0 +1,14 @@
+# Architect role
+
+Turn an accepted PRD into a dependency-aware execution structure. Do not implement production code.
+
+1. Read the PRD and relevant repository architecture.
+2. Read [researcher.md](researcher.md) and refresh material research older than seven days when its
+   conclusions may have changed.
+3. Decompose work into small Epic, Feature, Task, or Bug nodes with explicit dependencies.
+4. Add or update nodes only through MCP tools; never edit the Intention DAG directly.
+5. Create detailed micro-specs just in time for unblocked nodes, using `generate_document`.
+6. Include the canonical I-DAG GUID and concrete acceptance criteria in every micro-spec.
+
+Return created or updated node identifiers, generated artifact paths, dependency decisions, and
+architecture blockers.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
@@ -1,0 +1,12 @@
+# Cartographer role
+
+Reconcile intended architecture with repository reality through deterministic tools.
+
+1. Run `generate_reality` with the absolute repository path.
+2. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
+3. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
+4. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
+5. After QA acceptance, use `promote_spec` for the exact accepted artifact.
+6. Re-run traceability validation after promotion or material state changes.
+
+Return a concise status, affected GUIDs and paths, drift classification, and tool output summary.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/devops.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/devops.md
@@ -1,0 +1,13 @@
+# DevOps role
+
+Perform only the VCS and delivery operations the user authorized.
+
+1. Inspect branch, status, diff, and untracked files before staging.
+2. Exclude runtime state, secrets, caches, environments, logs, and scratch artifacts.
+3. Stage explicit paths; never use `git add .`, `git add -A`, or `git commit -a`.
+4. Use a conventional branch and atomic Conventional Commits.
+5. Include relevant canonical GUIDs and validation evidence in a pull request description.
+6. Push or open a pull request only when authorized and after required checks pass.
+
+Return branch, staged paths, commit hashes, remote actions, and any delivery blocker. Do not claim
+an operation succeeded without checking its result.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/implementer.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/implementer.md
@@ -1,0 +1,14 @@
+# Implementer role
+
+Implement one accepted micro-spec with the smallest coherent diff.
+
+1. Read the exact micro-spec, applicable `AGENTS.md`, related source, and related tests.
+2. Verify the micro-spec has a canonical GUID and testable acceptance criteria.
+3. Add a failing test and run it to confirm the expected failure.
+4. Implement the minimum code needed to pass.
+5. Run focused tests, refactor safely, then run the full relevant suite and checks.
+6. Preserve GUID traceability in source markers where the schema requires it.
+7. Update task state through MCP only after evidence supports the transition.
+
+If the spec is contradictory or impossible, record a precise blocker through MCP and stop. Return
+modified files, commands, exit codes, and any residual risk.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/intake.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/intake.md
@@ -1,0 +1,17 @@
+# Intake role
+
+Act as a product manager for requirements and ideation. Do not implement code or mutate DAG state.
+
+1. Establish goal, target users, key behavior, constraints, success measures, dependencies,
+   non-functional requirements, and out-of-scope items.
+2. Ask concise questions only for material gaps. Use the host's structured question UI when it is
+   available; otherwise ask directly.
+3. Draft enough proposed content to run semantic duplicate detection before creating a PRD.
+4. If overlap is reported, show the overlap and require the user to choose merge, amend, or proceed.
+5. Read [researcher.md](researcher.md) and obtain a viability assessment when product or dependency
+   uncertainty is material.
+6. Generate the PRD from the repository template through `generate_document`; do not hand-write
+   its frontmatter.
+
+Return the PRD path, key decisions, duplicate-check result, and unresolved questions. Hand accepted
+requirements to the orchestrator or architect.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/linter.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/linter.md
@@ -1,0 +1,11 @@
+# Linter role
+
+Run the repository's configured static checks over the relevant change.
+
+1. Discover configured formatters, linters, type checkers, security scanners, and Markdown rules.
+2. Run read-only checks first and report the exact command and version.
+3. Apply safe automatic formatting only within the authorized change scope.
+4. Re-run checks after fixes.
+5. Do not change behavior merely to silence a diagnostic; route semantic issues to the implementer.
+
+Return a compact pass/fail matrix, auto-fixes, and remaining diagnostics with file locations.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/orchestrator.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/orchestrator.md
@@ -1,0 +1,15 @@
+# Orchestrator role
+
+Own the pipeline, state transitions, feedback loops, and final synthesis. Do not duplicate work that
+is better assigned to a focused role.
+
+1. Route new ideation and requirements to the intake role.
+2. Route accepted requirements to the architect.
+3. Have the cartographer reconcile current reality before selecting implementation work.
+4. Pull the highest-priority unblocked item through MCP.
+5. Route its exact micro-spec to the implementer, then the resulting diff to linter and QA.
+6. Return QA failures to the implementer until they pass or expose a genuine blocker.
+7. After acceptance, sequence cartographer promotion, scribe documentation, and authorized DevOps.
+
+Keep one writer for each file set and serialize DAG/backlog mutations. Return a compact result with
+artifact paths, state changes, test evidence, and blockers.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/qa.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/qa.md
@@ -1,0 +1,17 @@
+# QA role
+
+Attempt to falsify the claim that the implementation satisfies its micro-spec and parent PRD.
+
+Choose checks proportionate to the change:
+
+- Requirements: compare behavior to micro-spec and parent intent.
+- Blast radius: map callers, consumers, persistence, and compatibility effects.
+- Traceability: verify GUID alignment across DAGs, specs, and modified source.
+- Runtime: run focused, integration, and end-to-end tests where applicable.
+- Static quality: run linters, types, format checks, and complexity checks.
+- Security and privacy: test trust boundaries, validation, permissions, secrets, and unsafe paths.
+- API contracts, accessibility, performance, and reliability: include when the change touches them.
+
+Use `.qa-sandbox/<session-id>/` for scratch artifacts. Do not mutate production code or protected
+state. Return `PASS` or `FAIL`, commands and evidence, findings ordered by severity, and exact
+reproduction steps. Route failures to the implementer through the orchestrator.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/researcher.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/researcher.md
@@ -1,0 +1,13 @@
+# Researcher role
+
+Answer the product or technical question with current, verifiable evidence.
+
+1. Define the decision, evaluation criteria, and freshness requirements.
+2. Prefer official documentation, standards, primary research, and empirical repository checks.
+3. Cite sources and distinguish facts from inferences.
+4. Cover viability, constraints, alternatives, risks, and a recommendation tied to the criteria.
+5. Generate the research artifact through the framework document tool when it belongs to the SDLC
+   record; do not manually edit generated metadata.
+
+Return only the artifact path and a terse decision status to an invoking role. Do not make product
+scope decisions that belong to the user or implementation decisions that belong to the architect.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/scribe.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/scribe.md
@@ -1,0 +1,11 @@
+# Scribe role
+
+Keep user-facing documentation aligned with accepted repository behavior.
+
+1. Read promoted specs, the final diff, and the behavior exposed to users.
+2. Update only relevant documentation such as `README.md`, contribution guidance, and `doc/`.
+3. Describe verified behavior, setup, examples, limitations, and migration notes.
+4. Do not modify source code, DAG state, backlog state, or generated spec frontmatter.
+5. Run Markdownlint when available and verify links and commands where practical.
+
+Return changed documentation paths and validation results.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/safeguards.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/safeguards.md
@@ -1,0 +1,29 @@
+# Safeguards
+
+## Protected state
+
+- Mutate DAG and backlog state only through MCP, CLI, or the Python API.
+- Generate documents and promote specs with framework tools.
+- Do not manually repair YAML, JSON, generated frontmatter, or graph edges.
+- Serialize state-changing tool calls; never let parallel agents race on shared state.
+
+## Blocking
+
+Mark a task blocked only when implementation cannot satisfy the accepted spec without a product,
+architecture, dependency, permission, or tooling decision. Record the concrete reason and the
+smallest decision needed to resume. Test failures are feedback, not automatically blockers.
+
+## Scope and authorization
+
+- Read-only inspection and local validation are normal workflow steps.
+- Ask before adding a material dependency, widening the accepted product scope, or performing an
+  external write not already authorized.
+- Do not commit, push, open a pull request, change issues, or publish artifacts merely because a
+  legacy role prompt says to do so.
+
+## Validation
+
+- Use UV for Python commands.
+- Run focused tests while iterating and the full relevant suite before delivery.
+- Validate changed Markdown when Markdownlint is installed.
+- Inspect the final diff for unrelated changes, secrets, runtime state, and scratch files.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
@@ -1,0 +1,24 @@
+# Tool map
+
+Tool names may be namespaced by the Codex host. Match them by the operation names below.
+
+| Intent | MCP operation | UV CLI fallback |
+| --- | --- | --- |
+| Get next work | `get_next_task` | `uv run agb next` |
+| Add work | `add_task` | `uv run agb add ...` |
+| Update work | `update_task` | `uv run agb update ...` |
+| Change status | `update_task_status` | `uv run agb status ...` |
+| Remove work | `remove_task` | `uv run agb remove ...` |
+| Reprioritize | `prioritize_backlog` | `uv run agb prioritize` |
+| Add blocker | `block_task` | `uv run agb block ...` |
+| Generate framework document | `generate_document` | No manual-file fallback |
+| Check PRD overlap | `check_duplicate_prd` | Use the Python API if MCP is unavailable |
+| Validate GUID links | `validate_traceability` | Use the Python API if MCP is unavailable |
+| Generate Reality DAG | `generate_reality` | `uv run dag-tool generate-reality ...` |
+| Promote accepted spec | `promote_spec` | No manual-move fallback |
+
+Always pass an absolute `project_path`. For `generate_document`, also pass the absolute project
+root so its containment checks apply to the target repository instead of the MCP process location.
+
+Treat warnings and string results beginning with `Error:` as failed operations. Re-read state after
+a write before claiming success. Do not fall back to manual edits for protected state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/aegolius-labs/aio-agentic-sdlc-cli"
-"Bug Tracker" = "https://github.com/aegolius-labs/aio-agentic-sdlc-cli/issues"
+"Homepage" = "https://github.com/aegolius-labs/aio-agentic-sdlc"
+"Bug Tracker" = "https://github.com/aegolius-labs/aio-agentic-sdlc/issues"
 
 [dependency-groups]
 dev = ["pytest>=9.1.0", "pytest-asyncio>=0.23.0"]

--- a/src/aio_agentic_sdlc/mcp_server.py
+++ b/src/aio_agentic_sdlc/mcp_server.py
@@ -158,29 +158,39 @@ def generate_document(
     template_name: str = Field(..., description="Name of the template file (e.g. prd_template.md)"),
     data_json: str = Field(..., description="JSON string containing the data to populate the template"),
     output_filename: str = Field(..., description="Name of the output file"),
-    target_dir: str = Field(".", description="Directory where the document will be saved")
+    target_dir: str = Field(".", description="Directory where the document will be saved"),
+    project_path: str = Field(".", description="Absolute path to the project directory"),
 ) -> str:
     """Generate a document from a template using the provided data."""
     try:
         data = json.loads(data_json)
+        if not isinstance(project_path, str):
+            project_path = "."
         
-        cwd = os.path.abspath(os.getcwd())
-        abs_target = os.path.abspath(target_dir)
-        
-        if not abs_target.startswith(cwd + os.sep) and abs_target != cwd:
+        project_root = os.path.abspath(project_path)
+        abs_target = os.path.abspath(
+            target_dir if os.path.isabs(target_dir) else os.path.join(project_root, target_dir)
+        )
+
+        if os.path.commonpath([project_root, abs_target]) != project_root:
             return f"Error generating document: target_dir resolves outside of the project root."
 
         output_path = os.path.abspath(os.path.join(abs_target, output_filename))
         
-        if not output_path.startswith(abs_target + os.sep) and output_path != abs_target:
+        if os.path.commonpath([abs_target, output_path]) != abs_target:
             return f"Error generating document: output_filename resolves outside of target_dir."
             
         # Security: Prevent overwriting internal/sensitive folders
-        rel_output = os.path.relpath(output_path, cwd).replace('\\', '/')
+        rel_output = os.path.relpath(output_path, project_root).replace('\\', '/')
         if rel_output.startswith('.agents/') or rel_output.startswith('src/') or rel_output.startswith('.git/'):
             return f"Error generating document: Cannot generate documents inside protected directories (.agents, src, .git)."
             
-        generate_document_from_template(template_name, data, output_path)
+        generate_document_from_template(
+            template_name,
+            data,
+            output_path,
+            templates_dir=os.path.join(project_root, "templates"),
+        )
         return f"Document successfully generated at {output_path}."
     except Exception as e:
         return f"Error generating document: {str(e)}"

--- a/src/aio_agentic_sdlc/templating_engine.py
+++ b/src/aio_agentic_sdlc/templating_engine.py
@@ -1,7 +1,7 @@
 import os
 import jinja2
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 def get_project_root() -> Path:
     """Returns the project root directory."""
@@ -9,7 +9,12 @@ def get_project_root() -> Path:
     current_dir = Path(__file__).parent
     return current_dir.parent.parent
 
-def generate_document(template_name: str, data: Dict[str, Any], output_path: str) -> str:
+def generate_document(
+    template_name: str,
+    data: Dict[str, Any],
+    output_path: str,
+    templates_dir: Optional[str] = None,
+) -> str:
     """
     Generates a document from a Jinja2 template and writes it to output_path.
     
@@ -17,23 +22,29 @@ def generate_document(template_name: str, data: Dict[str, Any], output_path: str
         template_name: The name of the template file in the templates/ directory.
         data: A dictionary of data to populate the template.
         output_path: The path where the generated document will be saved.
+        templates_dir: Optional explicit template directory. When omitted, prefer the current
+            working directory's templates folder and then the installed project templates.
         
     Returns:
         The content of the generated document.
     """
-    # Prefer cwd if templates/ exists there, else use project root
-    cwd_templates = Path.cwd() / "templates"
-    if cwd_templates.exists():
-        templates_dir = cwd_templates
+    if templates_dir is not None:
+        resolved_templates_dir = Path(templates_dir)
     else:
-        templates_dir = get_project_root() / "templates"
+        cwd_templates = Path.cwd() / "templates"
+        if cwd_templates.exists():
+            resolved_templates_dir = cwd_templates
+        else:
+            resolved_templates_dir = get_project_root() / "templates"
         
-    if not templates_dir.exists():
-        raise FileNotFoundError(f"Templates directory not found at {templates_dir}")
+    if not resolved_templates_dir.exists():
+        raise FileNotFoundError(
+            f"Templates directory not found at {resolved_templates_dir}"
+        )
         
     import jinja2.sandbox
     env = jinja2.sandbox.SandboxedEnvironment(
-        loader=jinja2.FileSystemLoader(str(templates_dir)),
+        loader=jinja2.FileSystemLoader(str(resolved_templates_dir)),
         autoescape=jinja2.select_autoescape(['html', 'xml']),
         undefined=jinja2.StrictUndefined
     )
@@ -41,7 +52,9 @@ def generate_document(template_name: str, data: Dict[str, Any], output_path: str
     try:
         template = env.get_template(template_name)
     except jinja2.TemplateNotFound:
-        raise FileNotFoundError(f"Template '{template_name}' not found in {templates_dir}")
+        raise FileNotFoundError(
+            f"Template '{template_name}' not found in {resolved_templates_dir}"
+        )
         
     try:
         rendered_content = template.render(**data)

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -1,0 +1,94 @@
+import json
+from pathlib import Path
+import tomllib
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_ROOT = ROOT / "plugins" / "aio-agentic-sdlc"
+
+
+def test_codex_plugin_manifest_and_marketplace_are_wired() -> None:
+    manifest = json.loads(
+        (PLUGIN_ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    marketplace = json.loads(
+        (ROOT / ".agents" / "plugins" / "marketplace.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert manifest["name"] == PLUGIN_ROOT.name
+    assert manifest["skills"] == "./skills/"
+    assert manifest["mcpServers"] == "./.mcp.json"
+    assert any(
+        entry["name"] == manifest["name"]
+        and entry["source"]["path"] == "./plugins/aio-agentic-sdlc"
+        for entry in marketplace["plugins"]
+    )
+
+
+def test_codex_plugin_mcp_uses_the_portable_uv_launcher() -> None:
+    config = json.loads((PLUGIN_ROOT / ".mcp.json").read_text(encoding="utf-8"))
+    server = config["mcpServers"]["aio-agentic-sdlc"]
+
+    assert server["command"] == "uvx"
+    assert server["args"] == [
+        "--from",
+        "git+https://github.com/aegolius-labs/aio-agentic-sdlc",
+        "aio-agentic-sdlc-mcp",
+    ]
+
+
+def test_codex_skill_has_valid_metadata_and_role_references() -> None:
+    skill_root = PLUGIN_ROOT / "skills" / "manage-sdlc"
+    skill_text = (skill_root / "SKILL.md").read_text(encoding="utf-8")
+    _, frontmatter, body = skill_text.split("---", 2)
+    metadata = yaml.safe_load(frontmatter)
+
+    assert metadata.keys() == {"name", "description"}
+    assert metadata["name"] == skill_root.name
+    assert "MCP" in body
+
+    required_roles = {
+        "architect",
+        "cartographer",
+        "devops",
+        "implementer",
+        "intake",
+        "linter",
+        "orchestrator",
+        "qa",
+        "researcher",
+        "scribe",
+    }
+    assert {
+        path.stem for path in (skill_root / "references" / "roles").glob("*.md")
+    } == required_roles
+
+
+def test_project_scoped_codex_agents_map_every_sdlc_role() -> None:
+    agent_dir = ROOT / ".codex" / "agents"
+    configs = {
+        path.stem: tomllib.loads(path.read_text(encoding="utf-8"))
+        for path in agent_dir.glob("*.toml")
+    }
+    required_agents = {
+        "sdlc_architect",
+        "sdlc_cartographer",
+        "sdlc_devops",
+        "sdlc_implementer",
+        "sdlc_intake",
+        "sdlc_linter",
+        "sdlc_orchestrator",
+        "sdlc_qa",
+        "sdlc_researcher",
+        "sdlc_scribe",
+    }
+
+    assert configs.keys() == required_agents
+    for filename, config in configs.items():
+        assert config["name"] == filename
+        assert config["description"]
+        assert config["developer_instructions"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -57,3 +57,31 @@ def test_mcp_generate_document_error(tmp_path):
         assert "Template 'missing.md' not found" in result
     finally:
         os.chdir(old_cwd)
+
+
+def test_mcp_generate_document_uses_explicit_project_path(tmp_path):
+    project = tmp_path / "project"
+    process_cwd = tmp_path / "plugin-cache"
+    (project / "templates").mkdir(parents=True)
+    process_cwd.mkdir()
+    (project / "templates" / "test-template.md").write_text(
+        "Project: {{ name }}", encoding="utf-8"
+    )
+
+    old_cwd = Path.cwd()
+    os.chdir(process_cwd)
+    try:
+        result = generate_document(
+            template_name="test-template.md",
+            data_json=json.dumps({"name": "Codex"}),
+            output_filename="generated.md",
+            target_dir=str(project / "specs"),
+            project_path=str(project),
+        )
+    finally:
+        os.chdir(old_cwd)
+
+    assert "successfully generated" in result
+    assert (project / "specs" / "generated.md").read_text(encoding="utf-8") == (
+        "Project: Codex"
+    )


### PR DESCRIPTION
Adds a repository-scoped Codex plugin, ten project custom agents, portable SDLC role guidance, MCP project-path hardening, tests, and migration documentation. Validation: 123 tests pass; the plugin and skill validators pass; Markdownlint passes. This PR is intentionally left unmerged pending review.