### PR TITLE
feat(intent): add auditable Intent IR v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Instead of relying on token-heavy LLM context windows or external integrations, 
 Intent IR can be validated strictly or reviewed without reading raw YAML:
 
 ```bash
+uv run dag-tool intent create-node --file intention-dag.yaml --node-id <guid> \
+  --type component --name "Capability" --payload-file intent.json
 uv run dag-tool validate-intent --file intention-dag.yaml
 uv run dag-tool intent-summary --file intention-dag.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The `aio-agentic-sdlc` framework includes several built-in features that ensure 
 - **QA Sandbox Isolation**: QA agents operate strictly within robust `.qa-sandbox/<session-id>/` environments to ensure they cannot leak or destructively modify core source files.
 - **MCP Server Integration**: Downstream subagents securely interact with the system via integrated MCP servers, most notably the Agentic Backlog server.
 - **Versioned Local State**: The execution backlog uses explicit schema and revision numbers, atomic replacement, stale-writer protection, and a local transaction audit log.
+- **Auditable Intent IR**: Intention nodes can preserve source provenance, assumptions, ambiguities, confidence, evidence-bound acceptance criteria, revision history, and approval state in a strict versioned schema.
 - **SDLC Scribe Agent**: An automated Scribe agent executes before the DevOps agent steps to ensure user-facing documentation (like this README) stays perfectly aligned with the codebase's true reality.
 
 ## Licensing Note
@@ -82,3 +83,13 @@ Instead of relying on token-heavy LLM context windows or external integrations, 
 - **Intention DAG (I-DAG)**: A graph-based structural representation of planned features and dependencies.
 - **Reality DAG (R-DAG)**: A deterministic reflection of the actual codebase logic.
 - **Canonical Traceability**: PRDs (Product Requirement Documents) in the `specs/` directory are firmly anchored to both DAGs using `aio-sdlc-node` GUID tags, allowing subagents to detect architectural drift automatically and execute Just-In-Time (JIT) TDD loops with zero hallucination.
+
+Intent IR can be validated strictly or reviewed without reading raw YAML:
+
+```bash
+uv run dag-tool validate-intent --file intention-dag.yaml
+uv run dag-tool intent-summary --file intention-dag.yaml
+```
+
+Use `--allow-partial` during migration while legacy nodes do not yet contain Intent IR. Strict
+validation remains the default.

--- a/doc/adr/0002-intent-ir-v1.md
+++ b/doc/adr/0002-intent-ir-v1.md
@@ -31,14 +31,18 @@ and fails when any node is missing the payload.
 or edit raw graph YAML. State mutation remains the responsibility of framework tools; these review
 and validation commands do not mutate the DAG.
 
+`set_intent` and `dag-tool intent set` are the only supported Intent IR mutation surfaces. They
+serialize writes with a local lock, require the caller's expected revision, preserve existing
+history, append exactly one revision, and atomically replace the DAG file.
+
 ## Consequences
 
 - Human statements and imported sources remain traceable through subsequent agent transformations.
 - Acceptance criteria state their required evidence before implementation is judged complete.
 - Low-confidence interpretations and open ambiguities are visible before downstream execution.
 - Legacy DAGs can migrate incrementally, but they do not pass strict Intent IR validation.
-- Intake and Cartographer still need deterministic creation and revision tools before the framework
-  can fully dogfood its roadmap.
+- Structural node creation and a benchmarked Intake-to-Intent translation loop remain necessary
+  before the framework can fully dogfood its roadmap.
 
 ## Alternatives Considered
 

--- a/doc/adr/0002-intent-ir-v1.md
+++ b/doc/adr/0002-intent-ir-v1.md
@@ -1,0 +1,50 @@
+# ADR 0002: Intent IR v1
+
+- Status: Accepted
+- Date: 2026-07-23
+
+## Context
+
+The Intention DAG identifies desired components and relationships, but its existing node fields do
+not explain where an interpretation came from, which assumptions or ambiguities shaped it, what
+observable evidence would satisfy it, or whether anyone approved it. Agents could therefore
+produce structurally valid YAML that was difficult to audit and easy to overstate.
+
+## Decision
+
+Intention DAG nodes may carry an `intent` payload conforming to the strict, versioned Intent IR v1
+schema. The payload records:
+
+- one or more provenance statements with durable source references;
+- explicit assumptions, unresolved or resolved ambiguities, and bounded confidence;
+- uniquely identified acceptance criteria with at least one required evidence reference each;
+- a monotonic revision history with the responsible actor and generator version;
+- the currently responsible agent and generator version; and
+- an explicit draft, review-required, approved, or rejected state with approval audit fields.
+
+Unknown fields fail validation. Revision history starts at one and increases strictly. Approved
+intent requires both an approver and approval timestamp. Existing DAG nodes remain loadable without
+an Intent IR payload during migration, while `dag-tool validate-intent` defaults to strict coverage
+and fails when any node is missing the payload.
+
+`dag-tool intent-summary` renders the interpretation for review without requiring a person to read
+or edit raw graph YAML. State mutation remains the responsibility of framework tools; these review
+and validation commands do not mutate the DAG.
+
+## Consequences
+
+- Human statements and imported sources remain traceable through subsequent agent transformations.
+- Acceptance criteria state their required evidence before implementation is judged complete.
+- Low-confidence interpretations and open ambiguities are visible before downstream execution.
+- Legacy DAGs can migrate incrementally, but they do not pass strict Intent IR validation.
+- Intake and Cartographer still need deterministic creation and revision tools before the framework
+  can fully dogfood its roadmap.
+
+## Alternatives Considered
+
+- Storing the fields in the existing free-form `attributes` dictionary was rejected because it
+  cannot provide a stable, validated contract.
+- Requiring every existing node to migrate immediately was rejected because it would make current
+  projects unreadable before framework-managed migration tooling exists.
+- Treating confidence or approval as prose was rejected because downstream policy needs bounded,
+  machine-readable values.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -63,6 +63,11 @@ but strict validation requires Intent IR on every node. `dag-tool intent-summary
 human-readable review surface without exposing raw graph YAML. The schema decision and migration
 tradeoffs are recorded in [ADR 0002](adr/0002-intent-ir-v1.md).
 
+Intent IR creation and revision are serialized by a lock under `.aio-sdlc/`. Callers provide the
+current node revision; stale writers fail instead of overwriting newer interpretation. Revisions
+must preserve the complete existing history and append exactly one next entry. DAG replacement is
+atomic, so a failed final replace leaves the prior canonical file intact.
+
 ### 3. State Loading
 
 The command handler reads the current state from `backlog.json` via `load_backlog()`. If the file does not exist, a schema-versioned empty envelope is returned. Unversioned `items` or `nodes` documents are migrated deterministically in memory; `aio-sdlc migrate-state` explicitly persists the current schema. A schema newer than the installed framework fails closed.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -20,7 +20,8 @@ graph TD
     end
     
     subgraph Local Persistence
-        CLI --> Intent[(intention-dag.yaml)]
+        CLI --> IntentReview[Intent IR validation and review]
+        IntentReview --> Intent[(intention-dag.yaml)]
         CLI --> Reality[(reality-dag.yaml)]
         CLI --> ReadJSON[load_backlog]
         ReadJSON --> FileDB[(backlog.json)]
@@ -54,6 +55,13 @@ The local files have distinct responsibilities:
 - `.agentic-backlog.json` is a retired generated artifact. Runtime code does not read it; `aio-sdlc migrate-state --retire-legacy` preserves a hash-named copy under ignored operational state before removing it.
 
 Framework tools, rather than hand edits, perform state transitions. External issue trackers may be reintroduced later as one-way projections, but they cannot select or replace the authoritative state.
+
+Intention DAG nodes can embed the versioned Intent IR v1 contract. Intent IR records provenance,
+assumptions, ambiguities, confidence, acceptance criteria and their required evidence, revision
+history, generator ownership, and approval state. Existing nodes remain readable during migration,
+but strict validation requires Intent IR on every node. `dag-tool intent-summary` provides a
+human-readable review surface without exposing raw graph YAML. The schema decision and migration
+tradeoffs are recorded in [ADR 0002](adr/0002-intent-ir-v1.md).
 
 ### 3. State Loading
 

--- a/intention-dag.yaml
+++ b/intention-dag.yaml
@@ -275,6 +275,340 @@ nodes:
   name: Health Check Endpoint
   domain: orchestration
   description: Lightweight health check endpoint for liveness probes
+- id: 7bcd1683-2a10-5cbc-ab91-440ea920eaf1
+  type: component
+  name: Intent IR v1
+  domain: product-kernel
+  description: Auditable intermediate representation compiled from human intent.
+  intent:
+    schema_version: 1
+    provenance:
+    - source_type: human_statement
+      reference: chat:project-review:roadmap-request
+      statement: Use the AIO SDLC framework to add the recommendations to the project's
+        roadmap and get the project back on track.
+    - source_type: document
+      reference: .aio-sdlc-recovery-roadmap.md#1-build-intent-ir-v1
+      statement: Build a validated, auditable Intent IR with provenance, assumptions,
+        ambiguities, confidence, evidence-bound acceptance criteria, revision history,
+        ownership, and approval state.
+    assumptions:
+    - Intention DAG nodes remain the canonical identity boundary.
+    - Legacy nodes must remain readable during framework-managed migration.
+    ambiguities:
+    - question: Which existing legacy Intention DAG nodes should be migrated first?
+      status: open
+    confidence: 0.9
+    acceptance_criteria:
+    - id: INTENT-IR-AC1
+      statement: Intent nodes preserve source provenance, assumptions, ambiguities,
+        bounded confidence, evidence requirements, revision history, ownership, and
+        approval state in a versioned schema.
+      required_evidence:
+      - test:intent-ir-schema-validation
+      - adr:0002-intent-ir-v1
+    - id: INTENT-IR-AC2
+      statement: Agents can create, revise, validate, and review Intent IR through
+        protected framework operations without editing raw YAML.
+      required_evidence:
+      - test:intent-ir-protected-mutation
+      - cli:dag-tool-intent
+      - mcp:create-set-validate-review-intent
+    revision_history:
+    - revision: 1
+      recorded_at: '2026-07-23T16:00:00Z'
+      actor: sdlc_intake
+      generator_version: aio-agentic-sdlc/0.23.0-dev
+      summary: Compiled the recovery roadmap's Intent IR milestone into canonical
+        intent.
+    responsible_agent: sdlc_cartographer
+    generator_version: aio-agentic-sdlc/0.23.0-dev
+    approval:
+      state: review_required
+- id: 6b1b3459-38a0-5cd5-8ff4-1453f17c3d76
+  type: component
+  name: Explicit Evidence Model
+  domain: verification
+  description: Evidence levels and references that justify or limit completion claims.
+  intent:
+    schema_version: 1
+    provenance:
+    - source_type: human_statement
+      reference: chat:project-review:recommendations
+      statement: Separate structural presence from actual requirement satisfaction
+        and explain every completion claim.
+    - source_type: document
+      reference: .aio-sdlc-recovery-roadmap.md#2-add-an-explicit-evidence-model
+      statement: Represent declared, mapped, structurally present, tested, behaviorally
+        verified, and approved as distinct evidence levels.
+    assumptions:
+    - Evidence references can initially be durable strings before typed evidence adapters
+      are added.
+    ambiguities:
+    - question: Which evidence types require cryptographic hashes versus stable repository
+        references?
+      status: open
+    confidence: 0.88
+    acceptance_criteria:
+    - id: EVIDENCE-AC1
+      statement: Completion distinguishes declared, mapped, structural, tested, behaviorally
+        verified, and approved evidence levels.
+      required_evidence:
+      - test:evidence-level-state-machine
+      - schema:evidence-v1
+    - id: EVIDENCE-AC2
+      statement: Reconciliation reports cite supporting evidence and list acceptance
+        criteria that remain unverified.
+      required_evidence:
+      - test:reconciliation-evidence-report
+      - demo:traceability-report
+    revision_history:
+    - revision: 1
+      recorded_at: '2026-07-23T16:01:00Z'
+      actor: sdlc_intake
+      generator_version: aio-agentic-sdlc/0.23.0-dev
+      summary: Compiled the explicit evidence model milestone.
+    responsible_agent: sdlc_architect
+    generator_version: aio-agentic-sdlc/0.23.0-dev
+    approval:
+      state: review_required
+- id: d64fbc3a-bdde-5672-8645-4aaa75464e46
+  type: component
+  name: Intent Translation Benchmark
+  domain: quality
+  description: Golden cases and measurable thresholds for human-intent translation.
+  intent:
+    schema_version: 1
+    provenance:
+    - source_type: human_statement
+      reference: chat:project-review:recommendations
+      statement: Measure the quality of translating human requests into canonical
+        intent.
+    - source_type: document
+      reference: .aio-sdlc-recovery-roadmap.md#3-benchmark-intent-translation
+      statement: Create golden requests and measure omissions, inventions, dependency
+        errors, unjustified completion, stability, and correction after feedback.
+    assumptions:
+    - Golden cases can be reviewed and versioned without embedding model-specific
+      outputs as requirements.
+    ambiguities:
+    - question: What initial failure thresholds are strict enough to be meaningful
+        without blocking all iteration?
+      status: open
+    confidence: 0.84
+    acceptance_criteria:
+    - id: BENCHMARK-AC1
+      statement: A versioned golden corpus covers requirements, constraints, dependencies,
+        ambiguities, evidence, and correction after feedback.
+      required_evidence:
+      - fixture:intent-translation-golden-corpus
+      - review:golden-case-approval
+    - id: BENCHMARK-AC2
+      statement: CI reports omissions, inventions, incorrect dependencies, unjustified
+        completion claims, repeated-run stability, and correction quality against
+        explicit thresholds.
+      required_evidence:
+      - test:intent-translation-benchmark
+      - ci:intent-quality-thresholds
+    revision_history:
+    - revision: 1
+      recorded_at: '2026-07-23T16:02:00Z'
+      actor: sdlc_intake
+      generator_version: aio-agentic-sdlc/0.23.0-dev
+      summary: Compiled the intent-translation benchmark milestone.
+    responsible_agent: sdlc_qa
+    generator_version: aio-agentic-sdlc/0.23.0-dev
+    approval:
+      state: review_required
+- id: cb02a996-6d3f-5610-9043-b1e768587d84
+  type: component
+  name: Closed-loop Reference Demo
+  domain: product-validation
+  description: Reproducible requirement-to-implementation-to-evidence demonstration.
+  intent:
+    schema_version: 1
+    provenance:
+    - source_type: human_statement
+      reference: chat:project-review:recommendations
+      statement: Prove one complete requirement-to-implementation-to-tests-to-traceability
+        workflow.
+    - source_type: document
+      reference: .aio-sdlc-recovery-roadmap.md#4-prove-one-closed-loop
+      statement: Publish one reproducible closed-loop demo with an understandable
+        traceability report and human approval gate.
+    assumptions:
+    - A narrow security or reliability requirement is a representative first demonstration.
+    ambiguities:
+    - question: Which external repository or isolated fixture should host the first
+        public demonstration?
+      status: open
+    confidence: 0.82
+    acceptance_criteria:
+    - id: DEMO-AC1
+      statement: A fresh checkout reproduces one requirement through intent, implementation,
+        tests, evidence, and approval.
+      required_evidence:
+      - demo:closed-loop-reproduction-script
+      - test:closed-loop-integration
+    - id: DEMO-AC2
+      statement: The resulting traceability report is understandable without knowledge
+        of framework internals.
+      required_evidence:
+      - artifact:human-readable-traceability-report
+      - review:external-reader-usability
+    revision_history:
+    - revision: 1
+      recorded_at: '2026-07-23T16:03:00Z'
+      actor: sdlc_intake
+      generator_version: aio-agentic-sdlc/0.23.0-dev
+      summary: Compiled the reproducible closed-loop demonstration milestone.
+    responsible_agent: sdlc_orchestrator
+    generator_version: aio-agentic-sdlc/0.23.0-dev
+    approval:
+      state: review_required
+- id: 4f6cdecf-639d-50e5-bc6d-ad71c1750000
+  type: component
+  name: Agent Runtime Portability
+  domain: orchestration
+  description: Runtime adapter boundary with validated Codex-native orchestration.
+  intent:
+    schema_version: 1
+    provenance:
+    - source_type: human_statement
+      reference: chat:antigravity-to-codex-plugin
+      statement: Convert the Antigravity-oriented framework into a portable Codex
+        plugin and avoid dependence on one agent runtime.
+    - source_type: document
+      reference: .aio-sdlc-recovery-roadmap.md#5-make-agents-runtime-portable
+      statement: Introduce runtime adapters, fix orchestration contracts, and validate
+        Codex-native execution without changing canonical state.
+    assumptions:
+    - The deterministic kernel remains independent from any model provider or host-specific
+      agent API.
+    ambiguities:
+    - question: Which second runtime should serve as the portability reference after
+        Codex?
+      status: open
+    confidence: 0.9
+    acceptance_criteria:
+    - id: RUNTIME-AC1
+      statement: Runtime-specific agent invocation is isolated behind a stable adapter
+        contract.
+      required_evidence:
+      - test:runtime-adapter-contract
+      - architecture:runtime-boundary
+    - id: RUNTIME-AC2
+      statement: Codex-native orchestration advances one selected task through its
+        lifecycle without modifying canonical intent semantics.
+      required_evidence:
+      - test:codex-orchestration-lifecycle
+      - demo:two-runtime-state-compatibility
+    revision_history:
+    - revision: 1
+      recorded_at: '2026-07-23T16:04:00Z'
+      actor: sdlc_intake
+      generator_version: aio-agentic-sdlc/0.23.0-dev
+      summary: Compiled the agent-runtime portability milestone.
+    responsible_agent: sdlc_architect
+    generator_version: aio-agentic-sdlc/0.23.0-dev
+    approval:
+      state: review_required
+- id: 15302505-8828-525a-bebb-f72621f467a1
+  type: component
+  name: Cross-language Ontology Portability
+  domain: reality-model
+  description: Shared Python and TypeScript observation ontology with GUID traceability.
+  intent:
+    schema_version: 1
+    provenance:
+    - source_type: human_statement
+      reference: chat:project-review:recommendations
+      statement: Support two materially different stacks to prove the ontology is
+        portable.
+    - source_type: document
+      reference: .aio-sdlc-recovery-roadmap.md#6-prove-ontology-portability
+      statement: Add TypeScript and prove mixed Python/TypeScript observations map
+        into one stable core ontology.
+    assumptions:
+    - TypeScript provides a materially different but widely useful second parser target.
+    ambiguities:
+    - question: Should the first TypeScript adapter parse the compiler API directly
+        or use tree-sitter-typescript?
+      status: open
+    confidence: 0.86
+    acceptance_criteria:
+    - id: ONTOLOGY-AC1
+      statement: Python and TypeScript parsers emit the same stable core node and
+        edge ontology.
+      required_evidence:
+      - test:cross-language-ontology-contract
+      - fixture:mixed-python-typescript-project
+    - id: ONTOLOGY-AC2
+      statement: Language-specific concepts do not leak into the core schema and GUID
+        traceability remains valid across languages.
+      required_evidence:
+      - test:mixed-project-guid-traceability
+      - review:ontology-boundary
+    revision_history:
+    - revision: 1
+      recorded_at: '2026-07-23T16:05:00Z'
+      actor: sdlc_intake
+      generator_version: aio-agentic-sdlc/0.23.0-dev
+      summary: Compiled the cross-language ontology portability milestone.
+    responsible_agent: sdlc_cartographer
+    generator_version: aio-agentic-sdlc/0.23.0-dev
+    approval:
+      state: review_required
+- id: 82579715-d088-51ac-999f-4a95235b561c
+  type: component
+  name: Product Hardening
+  domain: delivery
+  description: Stable installation, contracts, CI, licensing, recovery, and dogfooding
+    evidence.
+  intent:
+    schema_version: 1
+    provenance:
+    - source_type: human_statement
+      reference: chat:project-review:recommendations
+      statement: Stabilize installation, contracts, CI, documentation, licensing,
+        and externally understandable proof before positioning this as an ecosystem.
+    - source_type: document
+      reference: .aio-sdlc-recovery-roadmap.md#7-product-hardening
+      statement: Make CI, CLI, MCP, plugin installation, release contracts, licensing,
+        dogfooding reports, and recovery procedures reproducible.
+    assumptions:
+    - Product hardening follows proof of the core intent and evidence loop rather
+      than preceding it.
+    ambiguities:
+    - question: Should the long-term distribution use an OSI-approved core, dual licensing,
+        or a source-available commercial model?
+      status: open
+    confidence: 0.9
+    acceptance_criteria:
+    - id: HARDENING-AC1
+      statement: A clean environment can install and validate the CLI, MCP server,
+        and Codex plugin through stable documented contracts.
+      required_evidence:
+      - ci:clean-install-matrix
+      - test:plugin-install-smoke
+      - artifact:release-contract-documentation
+    - id: HARDENING-AC2
+      statement: The repository contains a deliberate license, recovery procedures,
+        and evidence-backed dogfooding reports understandable to external adopters.
+      required_evidence:
+      - file:LICENSE
+      - doc:recovery-procedure
+      - report:dogfooding-evidence
+    revision_history:
+    - revision: 1
+      recorded_at: '2026-07-23T16:06:00Z'
+      actor: sdlc_intake
+      generator_version: aio-agentic-sdlc/0.23.0-dev
+      summary: Compiled the product hardening milestone.
+    responsible_agent: sdlc_devops
+    generator_version: aio-agentic-sdlc/0.23.0-dev
+    approval:
+      state: review_required
 edges:
 - source: 4d76717e-55cd-4768-b05e-06a3cce1128b
   target: 54b91d55-08fe-48df-be35-445be7cd1e46
@@ -561,3 +895,35 @@ edges:
 - source: f1009cfe-9cde-4260-9235-72886d71fa94
   target: 1525a991-0ffa-4f82-b5a1-b23602346ca4
   type: contains
+- source: 6b1b3459-38a0-5cd5-8ff4-1453f17c3d76
+  target: 7bcd1683-2a10-5cbc-ab91-440ea920eaf1
+  type: depends_on
+  description: Evidence claims require the Intent IR acceptance and provenance contract.
+- source: d64fbc3a-bdde-5672-8645-4aaa75464e46
+  target: 7bcd1683-2a10-5cbc-ab91-440ea920eaf1
+  type: depends_on
+  description: Translation benchmarks evaluate the canonical Intent IR contract.
+- source: cb02a996-6d3f-5610-9043-b1e768587d84
+  target: 6b1b3459-38a0-5cd5-8ff4-1453f17c3d76
+  type: depends_on
+  description: The closed-loop demo requires explicit completion evidence.
+- source: cb02a996-6d3f-5610-9043-b1e768587d84
+  target: d64fbc3a-bdde-5672-8645-4aaa75464e46
+  type: depends_on
+  description: The demo should use measured intent translation behavior.
+- source: 4f6cdecf-639d-50e5-bc6d-ad71c1750000
+  target: cb02a996-6d3f-5610-9043-b1e768587d84
+  type: depends_on
+  description: Runtime portability is evaluated against the proven closed loop.
+- source: 15302505-8828-525a-bebb-f72621f467a1
+  target: 4f6cdecf-639d-50e5-bc6d-ad71c1750000
+  type: depends_on
+  description: Ontology portability follows a stable runtime-independent kernel.
+- source: 82579715-d088-51ac-999f-4a95235b561c
+  target: 4f6cdecf-639d-50e5-bc6d-ad71c1750000
+  type: depends_on
+  description: Product hardening requires stable runtime contracts.
+- source: 82579715-d088-51ac-999f-4a95235b561c
+  target: 15302505-8828-525a-bebb-f72621f467a1
+  type: depends_on
+  description: Product hardening follows proof of ontology portability.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
@@ -2,11 +2,16 @@
 
 Reconcile intended architecture with repository reality through deterministic tools.
 
-1. Run `generate_reality` with the absolute repository path.
-2. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
-3. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
-4. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
-5. After QA acceptance, use `promote_spec` for the exact accepted artifact.
-6. Re-run traceability validation after promotion or material state changes.
+1. For accepted intent targeting a new canonical capability, use `create_intent_node` with a stable
+   GUID and the complete Intake payload. For an existing node, use `set_intent` with its expected
+   revision. Never rewrite prior revision history.
+2. Run `validate_intent` and return `review_intent` output before downstream implementation. Route
+   open ambiguities, low confidence, or `review_required` state to the approval gate.
+3. Run `generate_reality` with the absolute repository path.
+4. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
+5. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
+6. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
+7. After QA acceptance, use `promote_spec` for the exact accepted artifact.
+8. Re-run traceability validation after promotion or material state changes.
 
 Return a concise status, affected GUIDs and paths, drift classification, and tool output summary.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/intake.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/intake.md
@@ -12,6 +12,11 @@ Act as a product manager for requirements and ideation. Do not implement code or
    uncertainty is material.
 6. Generate the PRD from the repository template through `generate_document`; do not hand-write
    its frontmatter.
+7. Compile accepted requirements into a complete Intent IR v1 payload. Preserve the originating
+   statement as provenance, identify assumptions and open ambiguities, bound confidence, define
+   acceptance criteria with required evidence, start revision history at one, and set approval to
+   `review_required`. Return the payload to the orchestrator or cartographer; Intake does not write
+   canonical DAG state.
 
-Return the PRD path, key decisions, duplicate-check result, and unresolved questions. Hand accepted
-requirements to the orchestrator or architect.
+Return the PRD path, Intent IR payload, key decisions, duplicate-check result, and unresolved
+questions. Hand accepted requirements to the orchestrator or architect.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
@@ -15,6 +15,8 @@ Tool names may be namespaced by the Codex host. Match them by the operation name
 | Check PRD overlap | `check_duplicate_prd` | Use the Python API if MCP is unavailable |
 | Validate GUID links | `validate_traceability` | Use the Python API if MCP is unavailable |
 | Generate Reality DAG | `generate_reality` | `uv run dag-tool generate-reality ...` |
+| Validate Intent IR | Not exposed yet | `uv run dag-tool validate-intent --file ...` |
+| Review Intent IR | Not exposed yet | `uv run dag-tool intent-summary --file ...` |
 | Promote accepted spec | `promote_spec` | No manual-move fallback |
 
 Always pass an absolute `project_path`. For `generate_document`, also pass the absolute project

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
@@ -15,8 +15,10 @@ Tool names may be namespaced by the Codex host. Match them by the operation name
 | Check PRD overlap | `check_duplicate_prd` | Use the Python API if MCP is unavailable |
 | Validate GUID links | `validate_traceability` | Use the Python API if MCP is unavailable |
 | Generate Reality DAG | `generate_reality` | `uv run dag-tool generate-reality ...` |
-| Validate Intent IR | Not exposed yet | `uv run dag-tool validate-intent --file ...` |
-| Review Intent IR | Not exposed yet | `uv run dag-tool intent-summary --file ...` |
+| Create intent node | `create_intent_node` | `uv run dag-tool intent create-node ...` |
+| Revise Intent IR | `set_intent` | `uv run dag-tool intent set ...` |
+| Validate Intent IR | `validate_intent` | `uv run dag-tool validate-intent --file ...` |
+| Review Intent IR | `review_intent` | `uv run dag-tool intent-summary --file ...` |
 | Promote accepted spec | `promote_spec` | No manual-move fallback |
 
 Always pass an absolute `project_path`. For `generate_document`, also pass the absolute project

--- a/src/aio_agentic_sdlc/dag_cli.py
+++ b/src/aio_agentic_sdlc/dag_cli.py
@@ -3,6 +3,8 @@ import json
 import sys
 from aio_agentic_sdlc.dag_manager import DAGManager
 from aio_agentic_sdlc.dag_models import Node, Edge, NodeType, EdgeType
+from aio_agentic_sdlc.intent_ir import IntentIR
+from aio_agentic_sdlc.intent_store import create_intent_node_file, update_intent_file
 from aio_agentic_sdlc.diffing_engine import DiffingEngine
 from aio_agentic_sdlc.reality_dag_generator import RealityDAGGenerator
 
@@ -52,6 +54,79 @@ def intent_summary(file, node_id):
         click.echo(manager.render_intent_summary(node_id=node_id))
     except Exception as e:
         click.secho(f"Error rendering Intent IR: {str(e)}", err=True, fg='red')
+        sys.exit(1)
+
+
+@cli.group("intent")
+def intent():
+    """Create or revise protected Intent IR payloads."""
+    pass
+
+
+@intent.command("create-node")
+@click.option('--file', required=True, type=click.Path(exists=True), help='Path to the Intention DAG yaml file.')
+@click.option('--node-id', required=True, help='Canonical node GUID.')
+@click.option('--type', 'node_type', required=True, type=click.Choice([t.value for t in NodeType]))
+@click.option('--name', required=True, help='Node name.')
+@click.option('--domain', help='Node domain.')
+@click.option('--description', help='Node description.')
+@click.option(
+    '--payload-file',
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help='JSON file containing the initial Intent IR v1 payload.',
+)
+def intent_create_node(file, node_id, node_type, name, domain, description, payload_file):
+    """Atomically create one canonical node with its initial Intent IR."""
+    try:
+        with open(payload_file, "r", encoding="utf-8") as payload:
+            intent_ir = IntentIR.model_validate(json.load(payload))
+        node = Node(
+            id=node_id,
+            type=NodeType(node_type),
+            name=name,
+            domain=domain,
+            description=description,
+            intent=intent_ir,
+        )
+        revision = create_intent_node_file(file, node)
+        click.echo(
+            f"Node '{node_id}' created with Intent IR revision {revision}."
+        )
+    except Exception as e:
+        click.secho(f"Error creating intent node: {str(e)}", err=True, fg='red')
+        sys.exit(1)
+
+
+@intent.command("set")
+@click.option('--file', required=True, type=click.Path(exists=True), help='Path to the Intention DAG yaml file.')
+@click.option('--node-id', required=True, help='Node ID receiving the Intent IR payload.')
+@click.option(
+    '--payload-file',
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help='JSON file containing one complete Intent IR payload.',
+)
+@click.option(
+    '--expected-revision',
+    required=True,
+    type=click.IntRange(min=0),
+    help='Current revision, or zero when creating the first Intent IR payload.',
+)
+def intent_set(file, node_id, payload_file, expected_revision):
+    """Create or revise Intent IR using optimistic revision protection."""
+    try:
+        with open(payload_file, "r", encoding="utf-8") as payload:
+            intent_ir = IntentIR.model_validate(json.load(payload))
+        revision = update_intent_file(
+            file,
+            node_id,
+            intent_ir,
+            expected_revision=expected_revision,
+        )
+        click.echo(f"Intent IR for node '{node_id}' saved at revision {revision}.")
+    except Exception as e:
+        click.secho(f"Error setting Intent IR: {str(e)}", err=True, fg='red')
         sys.exit(1)
 
 @cli.command()

--- a/src/aio_agentic_sdlc/dag_cli.py
+++ b/src/aio_agentic_sdlc/dag_cli.py
@@ -23,6 +23,37 @@ def validate(file):
         click.secho(f"Error validating DAG: {str(e)}", err=True, fg='red')
         sys.exit(1)
 
+
+@cli.command("validate-intent")
+@click.option('--file', required=True, type=click.Path(exists=True), help='Path to the Intention DAG yaml file.')
+@click.option(
+    '--require-all/--allow-partial',
+    default=True,
+    help='Require every node to contain Intent IR or allow legacy nodes.',
+)
+def validate_intent(file, require_all):
+    """Validate the Intent IR payloads and coverage of an Intention DAG."""
+    try:
+        manager = DAGManager.load(file)
+        manager.validate_intent_ir(require_all=require_all)
+        click.echo("Intent IR is valid.")
+    except Exception as e:
+        click.secho(f"Error validating Intent IR: {str(e)}", err=True, fg='red')
+        sys.exit(1)
+
+
+@cli.command("intent-summary")
+@click.option('--file', required=True, type=click.Path(exists=True), help='Path to the Intention DAG yaml file.')
+@click.option('--node-id', help='Limit the review to one node ID.')
+def intent_summary(file, node_id):
+    """Render a human-readable Intent IR review without raw YAML."""
+    try:
+        manager = DAGManager.load(file)
+        click.echo(manager.render_intent_summary(node_id=node_id))
+    except Exception as e:
+        click.secho(f"Error rendering Intent IR: {str(e)}", err=True, fg='red')
+        sys.exit(1)
+
 @cli.command()
 @click.option('--intention', required=True, type=click.Path(exists=True), help='Path to the Intention DAG yaml file.')
 @click.option('--reality', required=True, type=click.Path(exists=True), help='Path to the Reality DAG yaml file.')

--- a/src/aio_agentic_sdlc/dag_manager.py
+++ b/src/aio_agentic_sdlc/dag_manager.py
@@ -65,6 +65,73 @@ class DAGManager:
                 if dfs(node_id):
                     raise ValueError(f"Cycle detected involving node {node_id}.")
 
+    def validate_intent_ir(self, require_all: bool = True):
+        """Validate Intent IR coverage in addition to the base DAG constraints."""
+        self.validate()
+        if require_all:
+            missing = [node_id for node_id, node in self.nodes.items() if node.intent is None]
+            if missing:
+                raise ValueError(
+                    "Intent IR is missing for node(s): " + ", ".join(sorted(missing))
+                )
+
+    def render_intent_summary(self, node_id: str = None) -> str:
+        """Render an auditable Intent IR review without exposing raw DAG YAML."""
+        if node_id is not None:
+            nodes = [self.get_node(node_id)]
+        else:
+            nodes = list(self.nodes.values())
+
+        nodes = [node for node in nodes if node.intent is not None]
+        if not nodes:
+            return "No nodes contain Intent IR."
+
+        lines = [f"Intent review: {self.metadata.name}"]
+        for node in nodes:
+            intent = node.intent
+            lines.extend(
+                [
+                    "",
+                    f"## {node.name} ({node.id})",
+                    f"Confidence: {intent.confidence:.2f}",
+                    f"Approval: {intent.approval.state.value}",
+                    f"Responsible agent: {intent.responsible_agent}",
+                    f"Generator: {intent.generator_version}",
+                    "Provenance:",
+                ]
+            )
+            for source in intent.provenance:
+                lines.append(
+                    f"- [{source.source_type.value}] {source.reference}: {source.statement}"
+                )
+
+            lines.append("Acceptance criteria:")
+            for criterion in intent.acceptance_criteria:
+                lines.append(f"- {criterion.id}: {criterion.statement}")
+                for evidence in criterion.required_evidence:
+                    lines.append(f"  - Required evidence: {evidence}")
+
+            lines.append("Assumptions:")
+            lines.extend(f"- {assumption}" for assumption in intent.assumptions)
+            if not intent.assumptions:
+                lines.append("- None")
+
+            lines.append("Ambiguities:")
+            for ambiguity in intent.ambiguities:
+                resolution = f"; resolution: {ambiguity.resolution}" if ambiguity.resolution else ""
+                lines.append(f"- [{ambiguity.status.value}] {ambiguity.question}{resolution}")
+            if not intent.ambiguities:
+                lines.append("- None")
+
+            lines.append("Revision history:")
+            for revision in intent.revision_history:
+                lines.append(
+                    f"- r{revision.revision} {revision.recorded_at.isoformat()} "
+                    f"by {revision.actor}: {revision.summary}"
+                )
+
+        return "\n".join(lines)
+
     def add_node(self, node: Node):
         if node.id in self.nodes:
             raise ValueError(f"Node {node.id} already exists.")
@@ -76,7 +143,7 @@ class DAGManager:
         
         node = self.nodes[node_id]
         update_data = {k: v for k, v in kwargs.items() if v is not None}
-        updated_node = node.model_copy(update=update_data)
+        updated_node = Node.model_validate({**node.model_dump(), **update_data})
         self.nodes[node_id] = updated_node
 
     def remove_node(self, node_id: str):

--- a/src/aio_agentic_sdlc/dag_manager.py
+++ b/src/aio_agentic_sdlc/dag_manager.py
@@ -1,4 +1,6 @@
 import yaml
+import os
+import tempfile
 from typing import List, Dict, Any, Set
 from pydantic import ValidationError
 from aio_agentic_sdlc.dag_models import Metadata, Node, Edge, NodeType, EdgeType
@@ -26,8 +28,23 @@ class DAGManager:
             "nodes": [n.model_dump(mode='json', exclude_none=True) for n in self.nodes.values()],
             "edges": [e.model_dump(mode='json', exclude_none=True) for e in self.edges]
         }
-        with open(filepath, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, sort_keys=False, default_flow_style=False)
+        target = os.path.abspath(filepath)
+        target_dir = os.path.dirname(target) or "."
+        os.makedirs(target_dir, exist_ok=True)
+        fd, temp_path = tempfile.mkstemp(
+            dir=target_dir,
+            prefix=f".{os.path.basename(target)}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                yaml.dump(data, f, sort_keys=False, default_flow_style=False)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_path, target)
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
 
     def validate(self):
         # Reference Integrity

--- a/src/aio_agentic_sdlc/dag_models.py
+++ b/src/aio_agentic_sdlc/dag_models.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
 
+from aio_agentic_sdlc.intent_ir import IntentIR
+
 class NodeType(str, Enum):
     SYSTEM = "system"
     CONTAINER = "container"
@@ -32,6 +34,7 @@ class Node(BaseModel):
     domain: Optional[str] = None
     description: Optional[str] = None
     attributes: Optional[Dict[str, Any]] = None
+    intent: Optional[IntentIR] = None
 
 class Edge(BaseModel):
     source: str = Field(pattern=r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')

--- a/src/aio_agentic_sdlc/intent_ir.py
+++ b/src/aio_agentic_sdlc/intent_ir.py
@@ -1,0 +1,134 @@
+"""Versioned intermediate representation for auditable human intent."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, Literal, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class IntentModel(BaseModel):
+    """Strict base model for the stable Intent IR contract."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ProvenanceType(str, Enum):
+    HUMAN_STATEMENT = "human_statement"
+    CONVERSATION = "conversation"
+    DOCUMENT = "document"
+    IMPORTED_SPEC = "imported_spec"
+
+
+class AmbiguityStatus(str, Enum):
+    OPEN = "open"
+    RESOLVED = "resolved"
+
+
+class ApprovalState(str, Enum):
+    DRAFT = "draft"
+    REVIEW_REQUIRED = "review_required"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class Provenance(IntentModel):
+    source_type: ProvenanceType
+    reference: NonEmptyStr
+    statement: NonEmptyStr
+
+
+class Ambiguity(IntentModel):
+    question: NonEmptyStr
+    status: AmbiguityStatus = AmbiguityStatus.OPEN
+    resolution: NonEmptyStr | None = None
+
+    @model_validator(mode="after")
+    def require_resolution_when_resolved(self) -> Self:
+        if self.status == AmbiguityStatus.RESOLVED and not self.resolution:
+            raise ValueError("resolved ambiguity requires a resolution")
+        return self
+
+
+class AcceptanceCriterion(IntentModel):
+    id: NonEmptyStr
+    statement: NonEmptyStr
+    required_evidence: list[NonEmptyStr] = Field(min_length=1)
+
+
+class IntentRevision(IntentModel):
+    revision: int = Field(ge=1)
+    recorded_at: datetime
+    actor: NonEmptyStr
+    generator_version: NonEmptyStr
+    summary: NonEmptyStr
+
+    @field_validator("recorded_at")
+    @classmethod
+    def require_timezone_aware_timestamp(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("revision recorded_at must be timezone-aware")
+        return value
+
+
+class Approval(IntentModel):
+    state: ApprovalState
+    approved_by: NonEmptyStr | None = None
+    approved_at: datetime | None = None
+    rationale: NonEmptyStr | None = None
+
+    @field_validator("approved_at")
+    @classmethod
+    def require_timezone_aware_timestamp(cls, value: datetime | None) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("approval approved_at must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def require_approval_audit_fields(self) -> Self:
+        if self.state == ApprovalState.APPROVED:
+            if not self.approved_by:
+                raise ValueError("approved intent requires approved_by")
+            if self.approved_at is None:
+                raise ValueError("approved intent requires approved_at")
+        return self
+
+
+class IntentIR(IntentModel):
+    """Canonical Intent IR v1 payload attached to an Intention DAG node."""
+
+    schema_version: Literal[1] = 1
+    provenance: list[Provenance] = Field(min_length=1)
+    assumptions: list[NonEmptyStr] = Field(default_factory=list)
+    ambiguities: list[Ambiguity] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0)
+    acceptance_criteria: list[AcceptanceCriterion] = Field(min_length=1)
+    revision_history: list[IntentRevision] = Field(min_length=1)
+    responsible_agent: NonEmptyStr
+    generator_version: NonEmptyStr
+    approval: Approval
+
+    @model_validator(mode="after")
+    def validate_revision_history(self) -> Self:
+        criterion_ids = [criterion.id for criterion in self.acceptance_criteria]
+        if len(criterion_ids) != len(set(criterion_ids)):
+            raise ValueError("acceptance criterion IDs must be unique")
+
+        revisions = [entry.revision for entry in self.revision_history]
+        if revisions[0] != 1 or any(
+            current <= previous for previous, current in zip(revisions, revisions[1:])
+        ):
+            raise ValueError("revision history must start at 1 and be strictly increasing")
+        if self.revision_history[-1].generator_version != self.generator_version:
+            raise ValueError("latest revision generator_version must match Intent IR generator_version")
+        return self

--- a/src/aio_agentic_sdlc/intent_ir.py
+++ b/src/aio_agentic_sdlc/intent_ir.py
@@ -13,7 +13,6 @@ from pydantic import (
     model_validator,
 )
 
-
 NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
@@ -89,7 +88,9 @@ class Approval(IntentModel):
 
     @field_validator("approved_at")
     @classmethod
-    def require_timezone_aware_timestamp(cls, value: datetime | None) -> datetime | None:
+    def require_timezone_aware_timestamp(
+        cls, value: datetime | None
+    ) -> datetime | None:
         if value is not None and (value.tzinfo is None or value.utcoffset() is None):
             raise ValueError("approval approved_at must be timezone-aware")
         return value
@@ -128,7 +129,12 @@ class IntentIR(IntentModel):
         if revisions[0] != 1 or any(
             current <= previous for previous, current in zip(revisions, revisions[1:])
         ):
-            raise ValueError("revision history must start at 1 and be strictly increasing")
+            raise ValueError(
+                "revision history must start at 1 and be strictly increasing"
+            )
         if self.revision_history[-1].generator_version != self.generator_version:
-            raise ValueError("latest revision generator_version must match Intent IR generator_version")
+            raise ValueError(
+                "latest revision generator_version must match "
+                "Intent IR generator_version"
+            )
         return self

--- a/src/aio_agentic_sdlc/intent_store.py
+++ b/src/aio_agentic_sdlc/intent_store.py
@@ -1,0 +1,76 @@
+"""Serialized, optimistic updates for Intent IR in canonical DAG files."""
+
+from pathlib import Path
+
+from filelock import FileLock
+
+from .dag_manager import DAGManager
+from .dag_models import Node
+from .intent_ir import IntentIR
+
+
+def _lock_for(dag_path: Path) -> FileLock:
+    state_dir = dag_path.parent / ".aio-sdlc"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return FileLock(state_dir / f"{dag_path.name}.lock", timeout=10)
+
+
+def create_intent_node_file(filepath: str | Path, node: Node) -> int:
+    """Atomically create one canonical DAG node with validated Intent IR."""
+    if node.intent is None:
+        raise ValueError("canonical intent node creation requires Intent IR")
+    if len(node.intent.revision_history) != 1 or node.intent.revision_history[0].revision != 1:
+        raise ValueError("new canonical intent node must contain exactly revision 1")
+
+    dag_path = Path(filepath).resolve()
+    with _lock_for(dag_path):
+        manager = DAGManager.load(str(dag_path))
+        manager.add_node(node)
+        manager.save(str(dag_path))
+        return node.intent.revision_history[-1].revision
+
+
+def update_intent_file(
+    filepath: str | Path,
+    node_id: str,
+    intent: IntentIR,
+    *,
+    expected_revision: int,
+) -> int:
+    """Create or revise one node's Intent IR without rewriting audit history."""
+    if expected_revision < 0:
+        raise ValueError("expected_revision must be zero or greater")
+
+    dag_path = Path(filepath).resolve()
+    with _lock_for(dag_path):
+        manager = DAGManager.load(str(dag_path))
+        node = manager.get_node(node_id)
+        current = node.intent
+        current_revision = current.revision_history[-1].revision if current else 0
+        if current_revision != expected_revision:
+            raise ValueError(
+                f"stale Intent IR revision for node {node_id}: "
+                f"expected {expected_revision}, found {current_revision}"
+            )
+
+        if current is None:
+            if len(intent.revision_history) != 1 or intent.revision_history[0].revision != 1:
+                raise ValueError("new Intent IR must contain exactly revision 1")
+        else:
+            existing_history = current.revision_history
+            proposed_history = intent.revision_history
+            if (
+                len(proposed_history) != len(existing_history) + 1
+                or proposed_history[:-1] != existing_history
+            ):
+                raise ValueError(
+                    "Intent IR revision must preserve existing revision history and append one entry"
+                )
+            if proposed_history[-1].revision != current_revision + 1:
+                raise ValueError(
+                    f"next Intent IR revision must be {current_revision + 1}"
+                )
+
+        manager.update_node(node_id, intent=intent)
+        manager.save(str(dag_path))
+        return intent.revision_history[-1].revision

--- a/src/aio_agentic_sdlc/intent_store.py
+++ b/src/aio_agentic_sdlc/intent_store.py
@@ -19,7 +19,10 @@ def create_intent_node_file(filepath: str | Path, node: Node) -> int:
     """Atomically create one canonical DAG node with validated Intent IR."""
     if node.intent is None:
         raise ValueError("canonical intent node creation requires Intent IR")
-    if len(node.intent.revision_history) != 1 or node.intent.revision_history[0].revision != 1:
+    if (
+        len(node.intent.revision_history) != 1
+        or node.intent.revision_history[0].revision != 1
+    ):
         raise ValueError("new canonical intent node must contain exactly revision 1")
 
     dag_path = Path(filepath).resolve()
@@ -54,7 +57,10 @@ def update_intent_file(
             )
 
         if current is None:
-            if len(intent.revision_history) != 1 or intent.revision_history[0].revision != 1:
+            if (
+                len(intent.revision_history) != 1
+                or intent.revision_history[0].revision != 1
+            ):
                 raise ValueError("new Intent IR must contain exactly revision 1")
         else:
             existing_history = current.revision_history
@@ -64,7 +70,8 @@ def update_intent_file(
                 or proposed_history[:-1] != existing_history
             ):
                 raise ValueError(
-                    "Intent IR revision must preserve existing revision history and append one entry"
+                    "Intent IR revision must preserve existing revision history "
+                    "and append one entry"
                 )
             if proposed_history[-1].revision != current_revision + 1:
                 raise ValueError(

--- a/src/aio_agentic_sdlc/mcp_server.py
+++ b/src/aio_agentic_sdlc/mcp_server.py
@@ -9,6 +9,10 @@ from .core import (
     prioritize_items, get_next_item, load_backlog, VALID_STATUSES
 )
 from .templating_engine import generate_document as generate_document_from_template
+from .dag_manager import DAGManager
+from .dag_models import Node, NodeType
+from .intent_ir import IntentIR
+from .intent_store import create_intent_node_file, update_intent_file
 
 
 # Create the MCP server instance
@@ -233,6 +237,83 @@ def validate_traceability(project_path: str = Field(".", description="Absolute p
         return "Traceability Drift Detected:\n" + "\n".join(errors)
     except Exception as e:
         return f"Error validating traceability: {str(e)}"
+
+
+@mcp.tool()
+def set_intent(
+    node_id: str = Field(..., description="Canonical Intention DAG node GUID"),
+    payload_json: str = Field(..., description="Complete JSON-encoded Intent IR v1 payload"),
+    expected_revision: int = Field(..., ge=0, description="Current revision, or zero for creation"),
+    project_path: str = Field(".", description="Absolute path to the project directory"),
+) -> str:
+    """Create or revise one Intent IR payload with optimistic revision protection."""
+    try:
+        intention_path = os.path.join(os.path.abspath(project_path), "intention-dag.yaml")
+        intent = IntentIR.model_validate(json.loads(payload_json))
+        revision = update_intent_file(
+            intention_path,
+            node_id,
+            intent,
+            expected_revision=expected_revision,
+        )
+        return f"Intent IR for node '{node_id}' saved at revision {revision}."
+    except Exception as e:
+        return f"Error setting Intent IR: {str(e)}"
+
+
+@mcp.tool()
+def create_intent_node(
+    node_id: str = Field(..., description="Canonical Intention DAG node GUID"),
+    node_type: str = Field(..., description="Canonical DAG node type"),
+    name: str = Field(..., description="Human-readable node name"),
+    payload_json: str = Field(..., description="Initial JSON-encoded Intent IR v1 payload"),
+    domain: str = Field(None, description="Optional architectural domain"),
+    description: str = Field(None, description="Optional node description"),
+    project_path: str = Field(".", description="Absolute path to the project directory"),
+) -> str:
+    """Atomically create a canonical node with its initial Intent IR payload."""
+    try:
+        intention_path = os.path.join(os.path.abspath(project_path), "intention-dag.yaml")
+        node = Node(
+            id=node_id,
+            type=NodeType(node_type),
+            name=name,
+            domain=domain,
+            description=description,
+            intent=IntentIR.model_validate(json.loads(payload_json)),
+        )
+        revision = create_intent_node_file(intention_path, node)
+        return f"Node '{node_id}' created with Intent IR revision {revision}."
+    except Exception as e:
+        return f"Error creating intent node: {str(e)}"
+
+
+@mcp.tool()
+def validate_intent(
+    project_path: str = Field(".", description="Absolute path to the project directory"),
+    require_all: bool = Field(True, description="Require Intent IR on every node"),
+) -> str:
+    """Validate Intent IR payloads and coverage in the canonical Intention DAG."""
+    try:
+        intention_path = os.path.join(os.path.abspath(project_path), "intention-dag.yaml")
+        manager = DAGManager.load(intention_path)
+        manager.validate_intent_ir(require_all=require_all)
+        return "Intent IR validation passed."
+    except Exception as e:
+        return f"Error validating Intent IR: {str(e)}"
+
+
+@mcp.tool()
+def review_intent(
+    project_path: str = Field(".", description="Absolute path to the project directory"),
+    node_id: str = Field(None, description="Optional node GUID to review"),
+) -> str:
+    """Render a human-readable review of canonical Intent IR payloads."""
+    try:
+        intention_path = os.path.join(os.path.abspath(project_path), "intention-dag.yaml")
+        return DAGManager.load(intention_path).render_intent_summary(node_id=node_id)
+    except Exception as e:
+        return f"Error reviewing Intent IR: {str(e)}"
 
 @mcp.tool()
 def promote_spec(

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -68,6 +68,32 @@ def test_codex_skill_has_valid_metadata_and_role_references() -> None:
     } == required_roles
 
 
+def test_codex_skill_routes_intent_ir_through_protected_tools() -> None:
+    skill_root = PLUGIN_ROOT / "skills" / "manage-sdlc"
+    tools = (skill_root / "references" / "tools.md").read_text(encoding="utf-8")
+    intake = (skill_root / "references" / "roles" / "intake.md").read_text(
+        encoding="utf-8"
+    )
+    cartographer = (
+        skill_root / "references" / "roles" / "cartographer.md"
+    ).read_text(encoding="utf-8")
+
+    assert all(
+        operation in tools
+        for operation in (
+            "create_intent_node",
+            "set_intent",
+            "validate_intent",
+            "review_intent",
+        )
+    )
+    assert "Intent IR v1" in intake
+    assert "does not write" in intake.lower()
+    assert "canonical DAG state" in intake
+    assert "set_intent" in cartographer
+    assert "do not patch DAG files" in cartographer
+
+
 def test_project_scoped_codex_agents_map_every_sdlc_role() -> None:
     agent_dir = ROOT / ".codex" / "agents"
     configs = {

--- a/tests/test_intent_ir.py
+++ b/tests/test_intent_ir.py
@@ -19,7 +19,6 @@ from aio_agentic_sdlc.intent_ir import (
     ProvenanceType,
 )
 
-
 NODE_ID = "00000000-0000-0000-0000-0000000000a1"
 
 
@@ -65,7 +64,14 @@ def _intent_ir() -> IntentIR:
 def test_intent_ir_round_trips_through_dag_yaml(tmp_path):
     manager = DAGManager(
         Metadata(name="Intent", version="1.0"),
-        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter", intent=_intent_ir())],
+        [
+            Node(
+                id=NODE_ID,
+                type=NodeType.COMPONENT,
+                name="Rate limiter",
+                intent=_intent_ir(),
+            )
+        ],
         [],
     )
     path = tmp_path / "intention-dag.yaml"
@@ -167,7 +173,14 @@ def test_strict_intent_validation_reports_nodes_without_intent():
 def test_node_updates_revalidate_intent_ir():
     manager = DAGManager(
         Metadata(name="Intent", version="1.0"),
-        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter", intent=_intent_ir())],
+        [
+            Node(
+                id=NODE_ID,
+                type=NodeType.COMPONENT,
+                name="Rate limiter",
+                intent=_intent_ir(),
+            )
+        ],
         [],
     )
     invalid_intent = _intent_ir().model_dump()
@@ -180,7 +193,14 @@ def test_node_updates_revalidate_intent_ir():
 def test_intent_summary_is_reviewable_without_raw_yaml():
     manager = DAGManager(
         Metadata(name="Intent", version="1.0"),
-        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter", intent=_intent_ir())],
+        [
+            Node(
+                id=NODE_ID,
+                type=NodeType.COMPONENT,
+                name="Rate limiter",
+                intent=_intent_ir(),
+            )
+        ],
         [],
     )
 
@@ -200,7 +220,14 @@ def test_intent_summary_is_reviewable_without_raw_yaml():
 def test_intent_cli_validates_and_summarizes(tmp_path):
     manager = DAGManager(
         Metadata(name="Intent", version="1.0"),
-        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter", intent=_intent_ir())],
+        [
+            Node(
+                id=NODE_ID,
+                type=NodeType.COMPONENT,
+                name="Rate limiter",
+                intent=_intent_ir(),
+            )
+        ],
         [],
     )
     path = tmp_path / "intention-dag.yaml"

--- a/tests/test_intent_ir.py
+++ b/tests/test_intent_ir.py
@@ -1,0 +1,216 @@
+from datetime import datetime, timezone
+
+import pytest
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from aio_agentic_sdlc.dag_cli import cli
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import Metadata, Node, NodeType
+from aio_agentic_sdlc.intent_ir import (
+    AcceptanceCriterion,
+    Ambiguity,
+    AmbiguityStatus,
+    Approval,
+    ApprovalState,
+    IntentIR,
+    IntentRevision,
+    Provenance,
+    ProvenanceType,
+)
+
+
+NODE_ID = "00000000-0000-0000-0000-0000000000a1"
+
+
+def _intent_ir() -> IntentIR:
+    return IntentIR(
+        provenance=[
+            Provenance(
+                source_type=ProvenanceType.HUMAN_STATEMENT,
+                reference="chat:turn-42",
+                statement="Password reset requests must be rate limited.",
+            )
+        ],
+        assumptions=["A shared rate-limit store is available."],
+        ambiguities=[
+            Ambiguity(
+                question="Should administrators bypass the limit?",
+                status=AmbiguityStatus.OPEN,
+            )
+        ],
+        confidence=0.8,
+        acceptance_criteria=[
+            AcceptanceCriterion(
+                id="AC-1",
+                statement="The sixth request in one minute returns HTTP 429.",
+                required_evidence=["integration-test:password-reset-rate-limit"],
+            )
+        ],
+        revision_history=[
+            IntentRevision(
+                revision=1,
+                recorded_at=datetime(2026, 7, 23, tzinfo=timezone.utc),
+                actor="sdlc_intake",
+                generator_version="aio-agentic-sdlc/0.23",
+                summary="Initial interpretation of the user request.",
+            )
+        ],
+        responsible_agent="sdlc_intake",
+        generator_version="aio-agentic-sdlc/0.23",
+        approval=Approval(state=ApprovalState.REVIEW_REQUIRED),
+    )
+
+
+def test_intent_ir_round_trips_through_dag_yaml(tmp_path):
+    manager = DAGManager(
+        Metadata(name="Intent", version="1.0"),
+        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter", intent=_intent_ir())],
+        [],
+    )
+    path = tmp_path / "intention-dag.yaml"
+
+    manager.save(str(path))
+    loaded = DAGManager.load(str(path))
+
+    assert loaded.get_node(NODE_ID).intent == _intent_ir()
+    loaded.validate_intent_ir(require_all=True)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("provenance", []),
+        ("acceptance_criteria", []),
+        ("revision_history", []),
+        ("confidence", -0.1),
+        ("confidence", 1.1),
+    ],
+)
+def test_intent_ir_rejects_incomplete_or_invalid_core_fields(field, value):
+    data = _intent_ir().model_dump()
+    data[field] = value
+
+    with pytest.raises(ValidationError):
+        IntentIR.model_validate(data)
+
+
+def test_intent_ir_rejects_non_increasing_revision_history():
+    data = _intent_ir().model_dump()
+    duplicate = data["revision_history"][0].copy()
+    data["revision_history"].append(duplicate)
+
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        IntentIR.model_validate(data)
+
+
+def test_intent_revision_requires_timezone_aware_timestamp():
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        IntentRevision(
+            revision=1,
+            recorded_at=datetime(2026, 7, 23),
+            actor="sdlc_intake",
+            generator_version="aio-agentic-sdlc/0.23",
+            summary="Naive timestamps are not auditable across hosts.",
+        )
+
+
+def test_intent_ir_rejects_duplicate_acceptance_criterion_ids():
+    data = _intent_ir().model_dump()
+    duplicate = data["acceptance_criteria"][0].copy()
+    duplicate["statement"] = "A separate condition with a reused identifier."
+    data["acceptance_criteria"].append(duplicate)
+
+    with pytest.raises(ValidationError, match="criterion IDs must be unique"):
+        IntentIR.model_validate(data)
+
+
+def test_acceptance_criterion_rejects_blank_evidence_reference():
+    with pytest.raises(ValidationError):
+        AcceptanceCriterion(
+            id="AC-1",
+            statement="The condition is observable.",
+            required_evidence=["   "],
+        )
+
+
+def test_resolved_ambiguity_requires_resolution():
+    with pytest.raises(ValidationError, match="resolution"):
+        Ambiguity(question="Which store?", status=AmbiguityStatus.RESOLVED)
+
+
+def test_approved_intent_requires_approval_audit_fields():
+    with pytest.raises(ValidationError, match="approved_by"):
+        Approval(state=ApprovalState.APPROVED)
+
+
+def test_approved_intent_requires_timezone_aware_approval_timestamp():
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        Approval(
+            state=ApprovalState.APPROVED,
+            approved_by="product-owner",
+            approved_at=datetime(2026, 7, 23),
+        )
+
+
+def test_strict_intent_validation_reports_nodes_without_intent():
+    manager = DAGManager(
+        Metadata(name="Legacy", version="1.0"),
+        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Legacy node")],
+        [],
+    )
+
+    with pytest.raises(ValueError, match=NODE_ID):
+        manager.validate_intent_ir(require_all=True)
+
+
+def test_node_updates_revalidate_intent_ir():
+    manager = DAGManager(
+        Metadata(name="Intent", version="1.0"),
+        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter", intent=_intent_ir())],
+        [],
+    )
+    invalid_intent = _intent_ir().model_dump()
+    invalid_intent["confidence"] = 2.0
+
+    with pytest.raises(ValidationError):
+        manager.update_node(NODE_ID, intent=invalid_intent)
+
+
+def test_intent_summary_is_reviewable_without_raw_yaml():
+    manager = DAGManager(
+        Metadata(name="Intent", version="1.0"),
+        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter", intent=_intent_ir())],
+        [],
+    )
+
+    summary = manager.render_intent_summary()
+
+    assert "Rate limiter" in summary
+    assert "chat:turn-42" in summary
+    assert "Password reset requests must be rate limited." in summary
+    assert "AC-1" in summary
+    assert "integration-test:password-reset-rate-limit" in summary
+    assert "Should administrators bypass the limit?" in summary
+    assert "review_required" in summary
+    assert "0.80" in summary
+    assert "nodes:" not in summary
+
+
+def test_intent_cli_validates_and_summarizes(tmp_path):
+    manager = DAGManager(
+        Metadata(name="Intent", version="1.0"),
+        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter", intent=_intent_ir())],
+        [],
+    )
+    path = tmp_path / "intention-dag.yaml"
+    manager.save(str(path))
+    runner = CliRunner()
+
+    validate_result = runner.invoke(cli, ["validate-intent", "--file", str(path)])
+    summary_result = runner.invoke(cli, ["intent-summary", "--file", str(path)])
+
+    assert validate_result.exit_code == 0
+    assert "Intent IR is valid" in validate_result.output
+    assert summary_result.exit_code == 0
+    assert "Rate limiter" in summary_result.output

--- a/tests/test_intent_mutation.py
+++ b/tests/test_intent_mutation.py
@@ -1,0 +1,248 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from click.testing import CliRunner
+
+from aio_agentic_sdlc.dag_cli import cli
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import Metadata, Node, NodeType
+from aio_agentic_sdlc.intent_ir import IntentIR
+from aio_agentic_sdlc.intent_store import create_intent_node_file, update_intent_file
+from aio_agentic_sdlc.mcp_server import (
+    create_intent_node,
+    review_intent,
+    set_intent,
+    validate_intent,
+)
+from tests.test_intent_ir import NODE_ID, _intent_ir
+
+
+def _write_legacy_dag(path):
+    DAGManager(
+        Metadata(name="Intent", version="1.0"),
+        [Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter")],
+        [],
+    ).save(str(path))
+
+
+def _revision_two() -> IntentIR:
+    data = _intent_ir().model_dump()
+    data["assumptions"].append("Limits are scoped by account ID.")
+    data["revision_history"].append(
+        {
+            "revision": 2,
+            "recorded_at": datetime(2026, 7, 23, tzinfo=timezone.utc) + timedelta(minutes=5),
+            "actor": "sdlc_cartographer",
+            "generator_version": "aio-agentic-sdlc/0.23",
+            "summary": "Clarified the rate-limit key.",
+        }
+    )
+    data["responsible_agent"] = "sdlc_cartographer"
+    return IntentIR.model_validate(data)
+
+
+def test_update_intent_file_creates_and_revises_with_expected_revision(tmp_path):
+    path = tmp_path / "intention-dag.yaml"
+    _write_legacy_dag(path)
+
+    update_intent_file(path, NODE_ID, _intent_ir(), expected_revision=0)
+    update_intent_file(path, NODE_ID, _revision_two(), expected_revision=1)
+
+    intent = DAGManager.load(str(path)).get_node(NODE_ID).intent
+    assert intent.revision_history[-1].revision == 2
+    assert intent.assumptions[-1] == "Limits are scoped by account ID."
+
+
+def test_create_intent_node_file_adds_node_and_payload_atomically(tmp_path):
+    path = tmp_path / "intention-dag.yaml"
+    DAGManager(Metadata(name="Intent", version="1.0"), [], []).save(str(path))
+    node = Node(
+        id=NODE_ID,
+        type=NodeType.COMPONENT,
+        name="Rate limiter",
+        intent=_intent_ir(),
+    )
+
+    create_intent_node_file(path, node)
+
+    stored = DAGManager.load(str(path)).get_node(NODE_ID)
+    assert stored.name == "Rate limiter"
+    assert stored.intent == _intent_ir()
+
+
+def test_create_intent_node_file_requires_intent_payload(tmp_path):
+    path = tmp_path / "intention-dag.yaml"
+    DAGManager(Metadata(name="Intent", version="1.0"), [], []).save(str(path))
+
+    with pytest.raises(ValueError, match="requires Intent IR"):
+        create_intent_node_file(
+            path,
+            Node(id=NODE_ID, type=NodeType.COMPONENT, name="Rate limiter"),
+        )
+
+
+def test_create_intent_node_file_requires_exactly_initial_revision(tmp_path):
+    path = tmp_path / "intention-dag.yaml"
+    DAGManager(Metadata(name="Intent", version="1.0"), [], []).save(str(path))
+
+    with pytest.raises(ValueError, match="exactly revision 1"):
+        create_intent_node_file(
+            path,
+            Node(
+                id=NODE_ID,
+                type=NodeType.COMPONENT,
+                name="Rate limiter",
+                intent=_revision_two(),
+            ),
+        )
+
+
+def test_update_intent_file_rejects_stale_writer(tmp_path):
+    path = tmp_path / "intention-dag.yaml"
+    _write_legacy_dag(path)
+    update_intent_file(path, NODE_ID, _intent_ir(), expected_revision=0)
+
+    with pytest.raises(ValueError, match="stale Intent IR revision"):
+        update_intent_file(path, NODE_ID, _revision_two(), expected_revision=0)
+
+
+def test_update_intent_file_rejects_history_rewrite(tmp_path):
+    path = tmp_path / "intention-dag.yaml"
+    _write_legacy_dag(path)
+    update_intent_file(path, NODE_ID, _intent_ir(), expected_revision=0)
+    rewritten = _revision_two().model_dump()
+    rewritten["revision_history"][0]["summary"] = "Rewritten history."
+
+    with pytest.raises(ValueError, match="preserve existing revision history"):
+        update_intent_file(
+            path,
+            NODE_ID,
+            IntentIR.model_validate(rewritten),
+            expected_revision=1,
+        )
+
+
+def test_update_intent_file_preserves_original_on_replace_failure(tmp_path, monkeypatch):
+    path = tmp_path / "intention-dag.yaml"
+    _write_legacy_dag(path)
+    before = path.read_bytes()
+
+    def fail_replace(_source, _target):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr("aio_agentic_sdlc.dag_manager.os.replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        update_intent_file(path, NODE_ID, _intent_ir(), expected_revision=0)
+
+    assert path.read_bytes() == before
+    assert not list(tmp_path.glob(".intention-dag.yaml.*.tmp"))
+
+
+def test_intent_cli_sets_payload_from_json_file(tmp_path):
+    dag_path = tmp_path / "intention-dag.yaml"
+    payload_path = tmp_path / "intent.json"
+    _write_legacy_dag(dag_path)
+    payload_path.write_text(_intent_ir().model_dump_json(indent=2), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "intent",
+            "set",
+            "--file",
+            str(dag_path),
+            "--node-id",
+            NODE_ID,
+            "--payload-file",
+            str(payload_path),
+            "--expected-revision",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "revision 1" in result.output
+    assert DAGManager.load(str(dag_path)).get_node(NODE_ID).intent is not None
+
+
+def test_intent_cli_creates_node_with_payload(tmp_path):
+    dag_path = tmp_path / "intention-dag.yaml"
+    payload_path = tmp_path / "intent.json"
+    DAGManager(Metadata(name="Intent", version="1.0"), [], []).save(str(dag_path))
+    payload_path.write_text(_intent_ir().model_dump_json(indent=2), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "intent",
+            "create-node",
+            "--file",
+            str(dag_path),
+            "--node-id",
+            NODE_ID,
+            "--type",
+            "component",
+            "--name",
+            "Rate limiter",
+            "--payload-file",
+            str(payload_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "created with Intent IR revision 1" in result.output
+
+
+def test_mcp_intent_tools_use_project_path_and_protected_file(tmp_path):
+    dag_path = tmp_path / "intention-dag.yaml"
+    _write_legacy_dag(dag_path)
+
+    write_result = set_intent(
+        node_id=NODE_ID,
+        payload_json=_intent_ir().model_dump_json(),
+        expected_revision=0,
+        project_path=str(tmp_path),
+    )
+    validation_result = validate_intent(project_path=str(tmp_path), require_all=True)
+    review_result = review_intent(project_path=str(tmp_path), node_id=NODE_ID)
+
+    assert "revision 1" in write_result
+    assert validation_result == "Intent IR validation passed."
+    assert "Rate limiter" in review_result
+    assert "chat:turn-42" in review_result
+
+
+def test_mcp_create_intent_node_uses_canonical_project_dag(tmp_path):
+    dag_path = tmp_path / "intention-dag.yaml"
+    DAGManager(Metadata(name="Intent", version="1.0"), [], []).save(str(dag_path))
+
+    result = create_intent_node(
+        node_id=NODE_ID,
+        node_type="component",
+        name="Rate limiter",
+        domain="security",
+        description="Limits password-reset requests.",
+        payload_json=_intent_ir().model_dump_json(),
+        project_path=str(tmp_path),
+    )
+
+    assert "created with Intent IR revision 1" in result
+    assert DAGManager.load(str(dag_path)).get_node(NODE_ID).domain == "security"
+
+
+def test_mcp_set_intent_rejects_invalid_json_without_mutation(tmp_path):
+    dag_path = tmp_path / "intention-dag.yaml"
+    _write_legacy_dag(dag_path)
+    before = dag_path.read_bytes()
+
+    result = set_intent(
+        node_id=NODE_ID,
+        payload_json=json.dumps({"confidence": 4}),
+        expected_revision=0,
+        project_path=str(tmp_path),
+    )
+
+    assert result.startswith("Error setting Intent IR:")
+    assert dag_path.read_bytes() == before

--- a/tests/test_intent_mutation.py
+++ b/tests/test_intent_mutation.py
@@ -32,7 +32,8 @@ def _revision_two() -> IntentIR:
     data["revision_history"].append(
         {
             "revision": 2,
-            "recorded_at": datetime(2026, 7, 23, tzinfo=timezone.utc) + timedelta(minutes=5),
+            "recorded_at": datetime(2026, 7, 23, tzinfo=timezone.utc)
+            + timedelta(minutes=5),
             "actor": "sdlc_cartographer",
             "generator_version": "aio-agentic-sdlc/0.23",
             "summary": "Clarified the rate-limit key.",
@@ -123,7 +124,9 @@ def test_update_intent_file_rejects_history_rewrite(tmp_path):
         )
 
 
-def test_update_intent_file_preserves_original_on_replace_failure(tmp_path, monkeypatch):
+def test_update_intent_file_preserves_original_on_replace_failure(
+    tmp_path, monkeypatch
+):
     path = tmp_path / "intention-dag.yaml"
     _write_legacy_dag(path)
     before = path.read_bytes()


### PR DESCRIPTION
## What changed

- Add a strict, versioned Intent IR v1 schema to Intention DAG nodes.
- Preserve provenance, assumptions, ambiguities, bounded confidence, evidence-bound acceptance criteria, revision history, generator ownership, and approval state.
- Add strict and migration-compatible Intent IR validation.
- Add a human-readable intent summary that does not require reviewing raw DAG YAML.
- Add locked, atomic create/revise operations with optimistic stale-revision protection for CLI and MCP callers.
- Revalidate node updates so invalid nested intent cannot bypass Pydantic validation.
- Document the contract in ADR 0002, architecture guidance, README usage, and the Codex plugin tool map.
- Dogfood the new path by adding seven provenance-backed recovery-roadmap nodes and eight dependency edges through framework commands.

## Why

Structural graph nodes alone cannot establish whether agents understood the originating human request or what evidence would justify completion. Intent IR makes that interpretation explicit, reviewable, and machine-validated before later orchestration relies on it.

## Compatibility

Existing DAG nodes remain readable while migration tooling is built. `dag-tool validate-intent` is strict by default, while `--allow-partial` supports legacy DAGs during migration.

The seven new roadmap nodes carry Intent IR v1. The remaining 48 legacy nodes are deliberately left readable but unmigrated, so this PR does not claim strict whole-DAG coverage yet.

This is a stacked PR targeting `codex/feat/versioned-local-state` (PR #60). After PR #60 merges, this PR can be retargeted to `main`.

## Validation

- `uv run --no-sync pytest -q` - 170 passed
- Existing Intention and Reality DAG validation
- Legacy-compatible Intent IR validation
- Codex skill and plugin validators
- Markdownlint - 0 issues
- `uv build` - wheel and source distribution built successfully

Two existing coroutine warnings remain in the test suite and are outside this PR's scope.
