### PR TITLE
fix(deps): patch js-yaml resource exhaustion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -758,9 +758,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- update transitive development dependency `js-yaml` from 4.2.0 to patched 4.3.0
- keep the existing Commitlint and cosmiconfig versions unchanged
- update only the lockfile URL, version, and SHA-512 integrity

## Security impact

Closes Dependabot alert #4 for GHSA-52cp-r559-cp3m / CVE-2026-59869. Vulnerable js-yaml merge-key chains can trigger quadratic CPU consumption. Version 4.3.0 introduces the patched merge-key limit.

## Dependency path

`@commitlint/cli@21.0.2 -> @commitlint/load@21.0.2 -> cosmiconfig@9.0.1 -> js-yaml@4.3.0`

Cosmiconfig already declares `js-yaml ^4.1.0`, so the update is compatible without a direct dependency override.

## Validation

- registry SHA-512 integrity matches `package-lock.json`
- `npm ci --ignore-scripts` succeeded
- `npm audit`: zero vulnerabilities
- `npm ls js-yaml --all`: only js-yaml 4.3.0
- Commitlint version and commit-range execution passed
- `uv run --no-sync pytest`: 170 passed
- `git diff --check` passed
