### PR TITLE
fix: enforce clean async resource lifecycles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,7 @@ source = "vcs"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = [
+  "error:coroutine .* was never awaited:RuntimeWarning",
+  "error::pytest.PytestUnraisableExceptionWarning",
+]

--- a/src/aio_agentic_sdlc/detect.py
+++ b/src/aio_agentic_sdlc/detect.py
@@ -17,17 +17,15 @@ def detect_frameworks(cwd="."):
             frameworks.append("npm")
 
     # Python
-    if os.path.exists(os.path.join(cwd, "pyproject.toml")) or os.path.exists(
-        os.path.join(cwd, "requirements.txt")
-    ):
+    pyproject_path = os.path.join(cwd, "pyproject.toml")
+    requirements_path = os.path.join(cwd, "requirements.txt")
+    if os.path.exists(pyproject_path) or os.path.exists(requirements_path):
         frameworks.append("python")
-        if (
-            os.path.exists(os.path.join(cwd, "uv.lock"))
-            or "uv"
-            in open(os.path.join(cwd, "pyproject.toml"), encoding="utf-8").read()
-            if os.path.exists(os.path.join(cwd, "pyproject.toml"))
-            else False
-        ):
+        uses_uv = os.path.exists(os.path.join(cwd, "uv.lock"))
+        if not uses_uv and os.path.exists(pyproject_path):
+            with open(pyproject_path, encoding="utf-8") as pyproject_file:
+                uses_uv = "uv" in pyproject_file.read()
+        if uses_uv:
             frameworks.append("uv")
 
     # Rust

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aio_agentic_sdlc.cli import main
 
@@ -16,7 +16,7 @@ def test_cli_plan(capsys):
 @patch("os.path.exists")
 @patch("os.path.isdir")
 @patch("glob.glob")
-@patch("asyncio.run")
+@patch("aio_agentic_sdlc.cli._run_architect_subagent", new_callable=AsyncMock)
 @patch("aio_agentic_sdlc.dag_manager.DAGManager")
 @patch("aio_agentic_sdlc.diffing_engine.DiffingEngine")
 @patch("aio_agentic_sdlc.archiver.PRDArchiver")
@@ -26,7 +26,7 @@ def test_plan_cmd_with_inbox_files(
     mock_archiver,
     mock_diff_engine,
     mock_dag_manager,
-    mock_asyncio_run,
+    mock_architect_subagent,
     mock_glob,
     mock_isdir,
     mock_exists,
@@ -57,7 +57,9 @@ def test_plan_cmd_with_inbox_files(
 
     plan_cmd(MagicMock())
 
-    mock_asyncio_run.assert_called_once()
+    mock_architect_subagent.assert_awaited_once_with(
+        ["inbox/prd1.md", "inbox/prd2.md", "inbox/prd3.md"]
+    )
     # Should archive prd1.md, try prd3.md (fails), skip prd2.md
     mock_archiver.return_value.archive.assert_any_call("inbox/prd1.md")
     mock_archiver.return_value.archive.assert_any_call("inbox/prd3.md")

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -19,6 +19,11 @@ class TestDetectFrameworks:
         (tmp_path / "pyproject.toml").write_text("[tool.uv]")
         assert "uv" in detect_frameworks(str(tmp_path))
 
+    def test_detect_python_uv_lock(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("")
+        (tmp_path / "uv.lock").write_text("")
+        assert detect_frameworks(str(tmp_path)) == ["python", "uv"]
+
     def test_detect_node_npm(self, tmp_path):
         (tmp_path / "package.json").write_text("{}")
         frameworks = detect_frameworks(str(tmp_path))

--- a/tests/test_functional_bug.py
+++ b/tests/test_functional_bug.py
@@ -1,10 +1,10 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 @patch("os.path.exists")
 @patch("os.path.isdir")
 @patch("glob.glob")
-@patch("asyncio.run")
+@patch("aio_agentic_sdlc.cli._run_architect_subagent", new_callable=AsyncMock)
 @patch("aio_agentic_sdlc.dag_manager.DAGManager")
 @patch("aio_agentic_sdlc.diffing_engine.DiffingEngine")
 @patch("aio_agentic_sdlc.archiver.PRDArchiver")
@@ -14,7 +14,7 @@ def test_cli_unconditional_archival_edge_case(
     mock_archiver,
     mock_diff_engine,
     mock_dag_manager,
-    mock_asyncio_run,
+    mock_architect_subagent,
     mock_glob,
     mock_isdir,
     mock_exists,
@@ -31,6 +31,9 @@ def test_cli_unconditional_archival_edge_case(
     mock_diff_instance.calculate_diff.return_value = {}
     mock_diff_engine.return_value = mock_diff_instance
     plan_cmd(MagicMock())
+    mock_architect_subagent.assert_awaited_once_with(
+        ["inbox/test_prd.md", "inbox/innocent_file.md"]
+    )
     archive_calls = [
         call[0][0] for call in mock_archiver.return_value.archive.call_args_list
     ]


### PR DESCRIPTION
## Summary

- exercise the real event loop while mocking only the external architect coroutine boundary
- verify the architect coroutine is awaited exactly once with the expected inbox files
- fail deterministically on unawaited-coroutine and unraisable-exception warnings
- close framework-detection file handles correctly after the stricter policy exposed the leak
- verify that uv.lock independently selects UV without relying on pyproject content

## Validation

- uv run --no-sync pytest -W error (171 passed)
- uv run --no-sync black --check src/aio_agentic_sdlc/detect.py tests/test_cli.py tests/test_detect.py tests/test_functional_bug.py
- uv run --no-sync ruff check src/aio_agentic_sdlc/detect.py tests/test_cli.py tests/test_detect.py tests/test_functional_bug.py
- uv build
- uv lock --check
- manage-sdlc skill validator
- Codex plugin validator
- git diff --check