### PR TITLE
feat(reconciliation): add evidence-gated DAG planning

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -5,5 +5,8 @@
   "MD013": {
     "line_length": 400,
     "heading_line_length": 100
+  },
+  "MD025": {
+    "front_matter_title": ""
   }
 }

--- a/README.md
+++ b/README.md
@@ -103,13 +103,18 @@ Reconcile identity evidence before creating an execution backlog:
 uv run dag-tool reconcile \
   --intention intention-dag.yaml \
   --reality reality-dag.yaml \
-  --max-items 100
+  --max-items 100 \
+  --max-candidates 20
 uv run dag-tool diff \
   --intention intention-dag.yaml \
   --reality reality-dag.yaml \
-  --max-tasks 100
+  --max-tasks 100 \
+  --max-candidates 20
 ```
 
 Both commands are read-only. Safe diffing is the default: it asks for mapping review or additional
 implementation evidence rather than interpreting a missing GUID as permission to create or delete
 code. The historical structural algorithm requires the explicit `--mode legacy-structural` option.
+Both top-level records and nested candidate identities are bounded while complete totals and
+truncation metadata remain visible. Report output refuses to overwrite DAG, backlog, audit, or lock
+state.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The `aio-agentic-sdlc` framework includes several built-in features that ensure 
 - **MCP Server Integration**: Downstream subagents securely interact with the system via integrated MCP servers, most notably the Agentic Backlog server.
 - **Versioned Local State**: The execution backlog uses explicit schema and revision numbers, atomic replacement, stale-writer protection, and a local transaction audit log.
 - **Auditable Intent IR**: Intention nodes can preserve source provenance, assumptions, ambiguities, confidence, evidence-bound acceptance criteria, revision history, and approval state in a strict versioned schema.
+- **Evidence-Gated Reconciliation**: GUID matches are confirmed deterministically, structural matches remain review candidates, and unmatched Reality observations never become deletion work by default.
 - **SDLC Scribe Agent**: An automated Scribe agent executes before the DevOps agent steps to ensure user-facing documentation (like this README) stays perfectly aligned with the codebase's true reality.
 
 ## Licensing Note
@@ -95,3 +96,20 @@ uv run dag-tool intent-summary --file intention-dag.yaml
 
 Use `--allow-partial` during migration while legacy nodes do not yet contain Intent IR. Strict
 validation remains the default.
+
+Reconcile identity evidence before creating an execution backlog:
+
+```bash
+uv run dag-tool reconcile \
+  --intention intention-dag.yaml \
+  --reality reality-dag.yaml \
+  --max-items 100
+uv run dag-tool diff \
+  --intention intention-dag.yaml \
+  --reality reality-dag.yaml \
+  --max-tasks 100
+```
+
+Both commands are read-only. Safe diffing is the default: it asks for mapping review or additional
+implementation evidence rather than interpreting a missing GUID as permission to create or delete
+code. The historical structural algorithm requires the explicit `--mode legacy-structural` option.

--- a/changes/evidence-gated-reconciliation/sdd.md
+++ b/changes/evidence-gated-reconciliation/sdd.md
@@ -1,0 +1,57 @@
+---
+document_type: sdd
+title: "Evidence-Gated Reconciliation Baseline"
+author: "sdlc_architect"
+date: "2026-07-30"
+related_prd: "specs/bootstrapping-legacy-reingestion/prd.md"
+node_id: "9015c8a3-fd14-5598-916d-d03fcf41e415"
+
+---
+# Evidence-Gated Reconciliation Baseline
+
+## 1. Architecture Overview
+
+Canonical Intention DAG node: `9015c8a3-fd14-5598-916d-d03fcf41e415`. Add a deterministic, read-only reconciliation layer before backlog diffing.
+The layer classifies identity matches and structural candidates but never upgrades a candidate to an approved mapping.
+Safe planning treats unmatched Reality observations as unclassified and unmatched Intention nodes as reconciliation work, not proof that code must be created.
+Legacy structural create/delete behavior remains available only through an explicit compatibility policy.
+
+### Acceptance criteria
+
+- RECONCILE-AC1: Reports classify confirmed GUID matches, unique structural candidates, ambiguous candidates, and unmapped intent with concrete evidence.
+- RECONCILE-AC2: Default planning emits no create, remove, or disconnect task solely from a GUID mismatch.
+- RECONCILE-AC3: Reports and safe diffs are deterministically bounded and expose totals plus truncation metadata.
+
+### Test strategy
+
+Use behavior-driven fixtures containing true GUID matches, unique normalized-name matches, duplicate-name ambiguity, type mismatches, unmatched reality, and over-limit results.
+Verify exact classifications, evidence, deterministic ordering, mutation-free operation, safe default diff output, explicit legacy compatibility, CLI JSON, and MCP JSON.
+
+## 2. System Components
+
+1. `ReconciliationEngine`: compares canonical Intention nodes with observed Reality nodes using deterministic signals only.
+2. `ReconciliationReport`: versioned JSON-safe totals, mappings, candidates, ambiguities, unmapped nodes, and truncation metadata.
+3. `DiffPolicy`: safe default versus explicitly requested legacy structural behavior.
+4. `DiffingEngine`: consumes reconciliation output and produces bounded review tasks in safe mode.
+5. CLI and MCP adapters: expose the same read-only report without duplicating policy logic.
+
+## 3. Data Model
+
+Each reconciliation record contains the canonical intent ID, optional Reality ID, classification, normalized evidence, and whether human approval is required.
+Confirmed records require identical GUIDs. Candidate records require exactly one type-compatible normalized-name match.
+Multiple matches are ambiguous. No match is unmapped. Unmatched Reality observations are summarized separately and are never deletion evidence.
+Reports carry `schema_version`, complete category totals, `returned_items`, `max_items`, and `truncated`.
+
+## 4. API Design
+
+`ReconciliationEngine(intention, reality).analyze(max_items=...)` returns a serializable report.
+`DiffingEngine(..., policy=DiffPolicy.safe()).calculate_diff()` is the default and creates reconciliation-review work only.
+`DiffPolicy.legacy_structural()` preserves the former raw structural algorithm for explicit callers.
+`dag-tool reconcile --intention ... --reality ... --max-items ...` prints JSON. MCP `reconcile_dags(project_path, max_items)` returns the same JSON report.
+
+## 5. Security Considerations
+
+Reconciliation is read-only and must not inject source markers, rewrite either DAG, or mutate backlog state.
+Candidate matching is deterministic and exact after normalization; semantic similarity cannot approve mappings.
+Destructive operations are absent from safe mode. Output limits constrain memory and prompt size while preserving full totals.
+CLI and MCP paths use existing validated DAG loading and project-root containment conventions.

--- a/changes/evidence-gated-reconciliation/sdd.md
+++ b/changes/evidence-gated-reconciliation/sdd.md
@@ -20,12 +20,12 @@ Legacy structural create/delete behavior remains available only through an expli
 
 - RECONCILE-AC1: Reports classify confirmed GUID matches, unique structural candidates, ambiguous candidates, and unmapped intent with concrete evidence.
 - RECONCILE-AC2: Default planning emits no create, remove, or disconnect task solely from a GUID mismatch.
-- RECONCILE-AC3: Reports and safe diffs are deterministically bounded and expose totals plus truncation metadata.
+- RECONCILE-AC3: Reports and safe diffs are deterministically bounded at both the top level and nested candidate level, and expose totals plus truncation metadata.
 
 ### Test strategy
 
-Use behavior-driven fixtures containing true GUID matches, unique normalized-name matches, duplicate-name ambiguity, type mismatches, unmatched reality, and over-limit results.
-Verify exact classifications, evidence, deterministic ordering, mutation-free operation, safe default diff output, explicit legacy compatibility, CLI JSON, and MCP JSON.
+Use behavior-driven fixtures containing true GUID matches, mixed-case textual GUID forms, unique normalized-name matches, Unicode and empty normalization keys, duplicate-name ambiguity, type mismatches, unmatched reality, duplicate or reordered edges, and over-limit results.
+Verify exact classifications, bounded nested evidence, complete totals, deterministic ordering, mutation-free operation, protected-state output rejection, safe default diff output, explicit legacy compatibility, CLI JSON, and MCP JSON.
 
 ## 2. System Components
 
@@ -38,20 +38,20 @@ Verify exact classifications, evidence, deterministic ordering, mutation-free op
 ## 3. Data Model
 
 Each reconciliation record contains the canonical intent ID, optional Reality ID, classification, normalized evidence, and whether human approval is required.
-Confirmed records require identical GUIDs. Candidate records require exactly one type-compatible normalized-name match.
+Confirmed records require the same canonical GUID value; original textual forms remain visible as source evidence. Duplicate textual forms of one canonical GUID fail closed. Candidate records require exactly one type-compatible normalized-name match.
 Multiple matches are ambiguous. No match is unmapped. Unmatched Reality observations are summarized separately and are never deletion evidence.
-Reports carry `schema_version`, complete category totals, `returned_items`, `max_items`, and `truncated`.
+Reports carry `schema_version`, complete category totals, `returned_items`, `max_items`, and `truncated`. Each non-confirmed intent record also carries complete candidate totals and a configurable bounded candidate list.
 
 ## 4. API Design
 
-`ReconciliationEngine(intention, reality).analyze(max_items=...)` returns a serializable report.
-`DiffingEngine(..., policy=DiffPolicy.safe()).calculate_diff()` is the default and creates reconciliation-review work only.
+`ReconciliationEngine(intention, reality).analyze(max_items=..., max_candidates=...)` returns a serializable report.
+`DiffingEngine(..., policy=DiffPolicy.safe(max_tasks=..., max_candidates=...)).calculate_diff()` is the default and creates reconciliation-review work only.
 `DiffPolicy.legacy_structural()` preserves the former raw structural algorithm for explicit callers.
-`dag-tool reconcile --intention ... --reality ... --max-items ...` prints JSON. MCP `reconcile_dags(project_path, max_items)` returns the same JSON report.
+`dag-tool reconcile --intention ... --reality ... --max-items ... --max-candidates ...` prints JSON. MCP `reconcile_dags(project_path, max_items, max_candidates)` returns the same JSON report.
 
 ## 5. Security Considerations
 
-Reconciliation is read-only and must not inject source markers, rewrite either DAG, or mutate backlog state.
+Reconciliation is read-only and must not inject source markers, rewrite either DAG, or mutate backlog, audit, or lock state. Report output rejects protected framework-state paths.
 Candidate matching is deterministic and exact after normalization; semantic similarity cannot approve mappings.
-Destructive operations are absent from safe mode. Output limits constrain memory and prompt size while preserving full totals.
+Destructive operations are absent from safe mode. Bounded collectors and indexed matching constrain memory, CPU, and prompt size while preserving full totals.
 CLI and MCP paths use existing validated DAG loading and project-root containment conventions.

--- a/changes/evidence-gated-reconciliation/self-dogfood-report.json
+++ b/changes/evidence-gated-reconciliation/self-dogfood-report.json
@@ -1,0 +1,223 @@
+{
+  "schema_version": 1,
+  "summary": {
+    "intention_nodes": 56,
+    "reality_nodes": 3573,
+    "confirmed": 1,
+    "candidate": 6,
+    "ambiguous": 0,
+    "unmapped": 49,
+    "unclassified_reality": 3572
+  },
+  "limit": {
+    "max_items": 10,
+    "total_items": 3628,
+    "returned_items": 10,
+    "truncated": true
+  },
+  "items": [
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+        "type": "component",
+        "name": "Evidence-Gated Reconciliation Baseline"
+      },
+      "reality_candidates": [
+        {
+          "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+          "type": "module",
+          "name": "reconciliation.py"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "9015c8a3-fd14-5598-916d-d03fcf41e415"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b",
+        "type": "component",
+        "name": "Reality DAG Generator"
+      },
+      "reality_candidates": [
+        {
+          "id": "5f9d3dc7-cd7e-5402-86cd-356a4b6846fb",
+          "type": "component",
+          "name": "RealityDAGGenerator"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "realitydaggenerator",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "6506870b-b262-4f54-b6e9-43de4a873a55",
+        "type": "component",
+        "name": "PRD Archiver"
+      },
+      "reality_candidates": [
+        {
+          "id": "ac41eaca-b3f9-55fc-850a-a633ffc6b723",
+          "type": "component",
+          "name": "PRDArchiver"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "prdarchiver",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "685b1d12-3eed-48f6-9fa8-b8ec88a5587f",
+        "type": "component",
+        "name": "Traceability Validator"
+      },
+      "reality_candidates": [
+        {
+          "id": "4332ee05-cded-51dc-b884-7249af9d97cd",
+          "type": "component",
+          "name": "TraceabilityValidator"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "traceabilityvalidator",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "9865715b-99a5-4dcb-ba92-90b03cc3cf1c",
+        "type": "component",
+        "name": "Tree-Sitter Parser"
+      },
+      "reality_candidates": [
+        {
+          "id": "68d91d09-7a15-5e5c-8387-68ac2ec30139",
+          "type": "component",
+          "name": "TreeSitterParser"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "treesitterparser",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "d0307d83-371e-4bb6-925d-84a4b70beb6b",
+        "type": "component",
+        "name": "Parser Factory"
+      },
+      "reality_candidates": [
+        {
+          "id": "a7278b66-0ac6-5e6b-91d7-0604d42cc40f",
+          "type": "component",
+          "name": "ParserFactory"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "parserfactory",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "fa35fa8a-b6b5-40ca-9080-b31421117e37",
+        "type": "component",
+        "name": "Diffing Engine"
+      },
+      "reality_candidates": [
+        {
+          "id": "6199cd62-9332-5ad1-b458-18bd2e865da1",
+          "type": "component",
+          "name": "DiffingEngine"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "diffingengine",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "07e7e16c-c4d7-4f59-ac98-5d33599f0270",
+        "type": "agent",
+        "name": "SDLC Architect Agent"
+      },
+      "reality_candidates": [],
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "09497db1-e4c8-43f3-8c27-ee8577b2b59f",
+        "type": "component",
+        "name": "TUI Dashboard"
+      },
+      "reality_candidates": [],
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "10d4c0ba-de03-49ac-ae0e-41048fd557ed",
+        "type": "component",
+        "name": "Daemon Watcher"
+      },
+      "reality_candidates": [],
+      "evidence": [],
+      "requires_approval": true
+    }
+  ]
+}

--- a/changes/evidence-gated-reconciliation/self-dogfood-report.json
+++ b/changes/evidence-gated-reconciliation/self-dogfood-report.json
@@ -2,67 +2,20 @@
   "schema_version": 1,
   "summary": {
     "intention_nodes": 56,
-    "reality_nodes": 3573,
-    "confirmed": 1,
-    "candidate": 6,
-    "ambiguous": 0,
-    "unmapped": 49,
-    "unclassified_reality": 3572
+    "reality_nodes": 3508,
+    "confirmed": 0,
+    "candidate": 4,
+    "ambiguous": 2,
+    "unmapped": 50,
+    "unclassified_reality": 3508
   },
   "limit": {
     "max_items": 10,
-    "total_items": 3628,
+    "total_items": 3564,
     "returned_items": 10,
     "truncated": true
   },
   "items": [
-    {
-      "subject_kind": "intent",
-      "classification": "confirmed",
-      "intent": {
-        "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
-        "type": "component",
-        "name": "Evidence-Gated Reconciliation Baseline"
-      },
-      "reality_candidates": [
-        {
-          "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
-          "type": "module",
-          "name": "reconciliation.py"
-        }
-      ],
-      "evidence": [
-        {
-          "kind": "canonical_guid",
-          "value": "9015c8a3-fd14-5598-916d-d03fcf41e415"
-        }
-      ],
-      "requires_approval": false
-    },
-    {
-      "subject_kind": "intent",
-      "classification": "candidate",
-      "intent": {
-        "id": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b",
-        "type": "component",
-        "name": "Reality DAG Generator"
-      },
-      "reality_candidates": [
-        {
-          "id": "5f9d3dc7-cd7e-5402-86cd-356a4b6846fb",
-          "type": "component",
-          "name": "RealityDAGGenerator"
-        }
-      ],
-      "evidence": [
-        {
-          "kind": "normalized_name_and_type",
-          "normalized_name": "realitydaggenerator",
-          "node_type": "component"
-        }
-      ],
-      "requires_approval": true
-    },
     {
       "subject_kind": "intent",
       "classification": "candidate",
@@ -78,6 +31,12 @@
           "name": "PRDArchiver"
         }
       ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
       "evidence": [
         {
           "kind": "normalized_name_and_type",
@@ -102,34 +61,16 @@
           "name": "TraceabilityValidator"
         }
       ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
       "evidence": [
         {
           "kind": "normalized_name_and_type",
           "normalized_name": "traceabilityvalidator",
-          "node_type": "component"
-        }
-      ],
-      "requires_approval": true
-    },
-    {
-      "subject_kind": "intent",
-      "classification": "candidate",
-      "intent": {
-        "id": "9865715b-99a5-4dcb-ba92-90b03cc3cf1c",
-        "type": "component",
-        "name": "Tree-Sitter Parser"
-      },
-      "reality_candidates": [
-        {
-          "id": "68d91d09-7a15-5e5c-8387-68ac2ec30139",
-          "type": "component",
-          "name": "TreeSitterParser"
-        }
-      ],
-      "evidence": [
-        {
-          "kind": "normalized_name_and_type",
-          "normalized_name": "treesitterparser",
           "node_type": "component"
         }
       ],
@@ -150,6 +91,12 @@
           "name": "ParserFactory"
         }
       ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
       "evidence": [
         {
           "kind": "normalized_name_and_type",
@@ -174,10 +121,86 @@
           "name": "DiffingEngine"
         }
       ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
       "evidence": [
         {
           "kind": "normalized_name_and_type",
           "normalized_name": "diffingengine",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "ambiguous",
+      "intent": {
+        "id": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b",
+        "type": "component",
+        "name": "Reality DAG Generator"
+      },
+      "reality_candidates": [
+        {
+          "id": "5f9d3dc7-cd7e-5402-86cd-356a4b6846fb",
+          "type": "component",
+          "name": "RealityDAGGenerator"
+        },
+        {
+          "id": "6cb3bf65-5eae-563d-9a9b-bf8bed4bea12",
+          "type": "component",
+          "name": "RealityDAGGenerator"
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 2,
+        "returned_candidates": 2,
+        "truncated": false
+      },
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "realitydaggenerator",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "ambiguous",
+      "intent": {
+        "id": "9865715b-99a5-4dcb-ba92-90b03cc3cf1c",
+        "type": "component",
+        "name": "Tree-Sitter Parser"
+      },
+      "reality_candidates": [
+        {
+          "id": "68d91d09-7a15-5e5c-8387-68ac2ec30139",
+          "type": "component",
+          "name": "TreeSitterParser"
+        },
+        {
+          "id": "d65a3132-e5c9-5048-8b20-ea0dd00fe24c",
+          "type": "component",
+          "name": "TreeSitterParser"
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 2,
+        "returned_candidates": 2,
+        "truncated": false
+      },
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "treesitterparser",
           "node_type": "component"
         }
       ],
@@ -192,6 +215,12 @@
         "name": "SDLC Architect Agent"
       },
       "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
       "evidence": [],
       "requires_approval": true
     },
@@ -204,6 +233,12 @@
         "name": "TUI Dashboard"
       },
       "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
       "evidence": [],
       "requires_approval": true
     },
@@ -216,6 +251,30 @@
         "name": "Daemon Watcher"
       },
       "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "1525a991-0ffa-4f82-b5a1-b23602346ca4",
+        "type": "endpoint",
+        "name": "Health Check Endpoint"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
       "evidence": [],
       "requires_approval": true
     }

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -77,7 +77,7 @@ atomic, so a failed final replace leaves the prior canonical file intact.
 Raw GUID inequality is not proof that implementation is missing or unwanted. Before backlog
 planning, `ReconciliationEngine` classifies each Intention node as:
 
-- `confirmed`: the Reality DAG contains the same canonical GUID;
+- `confirmed`: the Reality DAG contains the same canonical GUID value after canonicalization;
 - `candidate`: exactly one Reality node has the same normalized name and node type;
 - `ambiguous`: more than one node satisfies that deterministic structural signal; or
 - `unmapped`: no deterministic structural candidate exists.
@@ -87,14 +87,21 @@ mappings and does not mutate either DAG. Reality nodes without a confirmed GUID 
 `unclassified_reality`; they are not deletion evidence.
 
 Safe diffing is the default. It produces bounded mapping-review or implementation-investigation
-work and includes complete totals plus truncation metadata. It only reports drift for confirmed
+work and includes complete totals plus truncation metadata for both top-level work and nested
+candidate identities. Candidate matching uses a deterministic normalized-name/type index, and
+Unicode alphanumerics are preserved. It only reports drift for confirmed
 identities when Reality contains an observed value that contradicts intent. Missing observations
 are not contradictions. The former structural create/remove/disconnect algorithm remains available
 only through the explicit `legacy-structural` compatibility mode.
 
+Report writers reject canonical DAG, backlog, transaction-journal, and lock paths. Safe edge work
+canonicalizes endpoint GUIDs, deduplicates logical edges, and sorts them before applying limits.
+
 ```powershell
-uv run dag-tool reconcile --intention intention-dag.yaml --reality reality-dag.yaml
-uv run dag-tool diff --intention intention-dag.yaml --reality reality-dag.yaml
+uv run dag-tool reconcile --intention intention-dag.yaml --reality reality-dag.yaml `
+  --max-items 100 --max-candidates 20
+uv run dag-tool diff --intention intention-dag.yaml --reality reality-dag.yaml `
+  --max-tasks 100 --max-candidates 20
 uv run dag-tool diff --intention intention-dag.yaml --reality reality-dag.yaml `
   --mode legacy-structural
 ```

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -23,6 +23,10 @@ graph TD
         CLI --> IntentReview[Intent IR validation and review]
         IntentReview --> Intent[(intention-dag.yaml)]
         CLI --> Reality[(reality-dag.yaml)]
+        Intent --> Reconcile[Evidence-gated reconciliation]
+        Reality --> Reconcile
+        Reconcile --> SafePlan[Bounded review plan]
+        SafePlan --> ReadJSON
         CLI --> ReadJSON[load_backlog]
         ReadJSON --> FileDB[(backlog.json)]
         CLI --> Lock[Cross-process state lock]
@@ -67,6 +71,33 @@ Intent IR creation and revision are serialized by a lock under `.aio-sdlc/`. Cal
 current node revision; stale writers fail instead of overwriting newer interpretation. Revisions
 must preserve the complete existing history and append exactly one next entry. DAG replacement is
 atomic, so a failed final replace leaves the prior canonical file intact.
+
+### Evidence-gated reconciliation
+
+Raw GUID inequality is not proof that implementation is missing or unwanted. Before backlog
+planning, `ReconciliationEngine` classifies each Intention node as:
+
+- `confirmed`: the Reality DAG contains the same canonical GUID;
+- `candidate`: exactly one Reality node has the same normalized name and node type;
+- `ambiguous`: more than one node satisfies that deterministic structural signal; or
+- `unmapped`: no deterministic structural candidate exists.
+
+Candidates always require approval. The engine does not use semantic similarity to approve
+mappings and does not mutate either DAG. Reality nodes without a confirmed GUID are reported as
+`unclassified_reality`; they are not deletion evidence.
+
+Safe diffing is the default. It produces bounded mapping-review or implementation-investigation
+work and includes complete totals plus truncation metadata. It only reports drift for confirmed
+identities when Reality contains an observed value that contradicts intent. Missing observations
+are not contradictions. The former structural create/remove/disconnect algorithm remains available
+only through the explicit `legacy-structural` compatibility mode.
+
+```powershell
+uv run dag-tool reconcile --intention intention-dag.yaml --reality reality-dag.yaml
+uv run dag-tool diff --intention intention-dag.yaml --reality reality-dag.yaml
+uv run dag-tool diff --intention intention-dag.yaml --reality reality-dag.yaml `
+  --mode legacy-structural
+```
 
 ### 3. State Loading
 

--- a/doc/codex-plugin.md
+++ b/doc/codex-plugin.md
@@ -66,6 +66,7 @@ prompts include:
 - “Run this change through the agentic SDLC pipeline.”
 - “Show me the highest-priority unblocked task.”
 - “Generate the Reality DAG and report traceability drift.”
+- “Reconcile the Intention and Reality DAGs without proposing destructive cleanup.”
 
 For MCP calls, pass the absolute target repository as `project_path`. This is especially important
 when the plugin is installed because Codex runs the server from a cached plugin package, not from

--- a/intention-dag.yaml
+++ b/intention-dag.yaml
@@ -609,6 +609,68 @@ nodes:
     generator_version: aio-agentic-sdlc/0.23.0-dev
     approval:
       state: review_required
+- id: 9015c8a3-fd14-5598-916d-d03fcf41e415
+  type: component
+  name: Evidence-Gated Reconciliation Baseline
+  domain: verification
+  description: Deterministic, non-destructive bridge from canonical intent to observed
+    repository reality.
+  intent:
+    schema_version: 1
+    provenance:
+    - source_type: human_statement
+      reference: codex:task:get-back-on-track:2026-07-30
+      statement: Tackle the missing intent-to-reality bridge and proceed without further
+        input unless a material product choice is required.
+    - source_type: document
+      reference: specs/bootstrapping-legacy-reingestion/prd.md
+      statement: Bootstrap an existing project safely while preserving canonical GUID
+        traceability and avoiding destructive modification.
+    assumptions:
+    - Intention DAG node GUIDs remain canonical and Reality observations cannot silently
+      redefine them.
+    - Deterministic structural evidence may propose a mapping but cannot approve it.
+    - Unmatched Reality nodes are unclassified implementation observations, not deletion
+      candidates.
+    ambiguities: []
+    confidence: 0.96
+    acceptance_criteria:
+    - id: RECONCILE-AC1
+      statement: A deterministic reconciliation report distinguishes confirmed GUID
+        matches, unique structural candidates, ambiguous candidates, and unmapped
+        intent without mutating canonical state.
+      required_evidence:
+      - test:reconciliation-classification
+      - cli:dag-tool-reconcile
+      - mcp:reconcile-dags
+    - id: RECONCILE-AC2
+      statement: Default diff and backlog planning never propose create, delete, or
+        disconnect operations solely because an Intention and Reality GUID do not
+        match.
+      required_evidence:
+      - test:evidence-gated-diff
+      - test:unmatched-reality-is-not-deletion
+    - id: RECONCILE-AC3
+      statement: Planning remains bounded and emits reviewable reconciliation work
+        with explicit evidence and truncation metadata instead of an unbounded destructive
+        backlog.
+      required_evidence:
+      - test:bounded-reconciliation-plan
+      - report:self-dogfood-reconciliation
+    revision_history:
+    - revision: 1
+      recorded_at: '2026-07-30T21:19:57Z'
+      actor: sdlc_intake
+      generator_version: aio-agentic-sdlc/0.24.1-dev
+      summary: Compiled the approved evidence-gated reconciliation recovery slice.
+    responsible_agent: sdlc_cartographer
+    generator_version: aio-agentic-sdlc/0.24.1-dev
+    approval:
+      state: approved
+      approved_by: Felix
+      approved_at: '2026-07-30T21:19:57Z'
+      rationale: The repository owner explicitly authorized this recovery milestone
+        and delegated implementation judgment.
 edges:
 - source: 4d76717e-55cd-4768-b05e-06a3cce1128b
   target: 54b91d55-08fe-48df-be35-445be7cd1e46
@@ -927,3 +989,15 @@ edges:
   target: 15302505-8828-525a-bebb-f72621f467a1
   type: depends_on
   description: Product hardening follows proof of ontology portability.
+- source: 9015c8a3-fd14-5598-916d-d03fcf41e415
+  target: 7bcd1683-2a10-5cbc-ab91-440ea920eaf1
+  type: depends_on
+  description: Reconciliation evidence uses the auditable Intent IR contract.
+- source: 6b1b3459-38a0-5cd5-8ff4-1453f17c3d76
+  target: 9015c8a3-fd14-5598-916d-d03fcf41e415
+  type: depends_on
+  description: Evidence levels build on deterministic reconciliation classifications.
+- source: d64fbc3a-bdde-5672-8645-4aaa75464e46
+  target: 9015c8a3-fd14-5598-916d-d03fcf41e415
+  type: depends_on
+  description: Translation benchmarks require a safe reconciliation oracle.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
@@ -15,7 +15,9 @@ framework tools for documents and DAG state.
 ## 3. Reality reconciliation
 
 Follow [roles/cartographer.md](roles/cartographer.md). Generate the Reality DAG, validate GUID
-traceability, classify drift, and route the repair:
+traceability, run evidence-gated identity reconciliation, classify drift, and route the repair.
+Only identical canonical GUIDs are confirmed. Exact structural matches remain approval-required
+candidates, and unmatched Reality observations are unclassified rather than deletion candidates:
 
 - Reality drift: accepted intent is not implemented; route to the implementer.
 - Intention drift: code exists without accepted intent; route to the architect for validation.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
@@ -8,9 +8,10 @@ Reconcile intended architecture with repository reality through deterministic to
 2. Run `validate_intent` and return `review_intent` output before downstream implementation. Route
    open ambiguities, low confidence, or `review_required` state to the approval gate.
 3. Run `generate_reality` with the absolute repository path.
-4. Run `reconcile_dags` before diffing. Treat only identical canonical GUIDs as confirmed; exact
+4. Run `reconcile_dags` before diffing. Treat only the same canonical GUID value as confirmed; exact
    structural matches remain approval-required candidates, and unmatched Reality observations are
-   unclassified rather than deletion candidates.
+   unclassified rather than deletion candidates. Keep both record and nested-candidate limits
+   bounded, and retain their complete totals and truncation metadata.
 5. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
 6. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
 7. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
@@ -8,10 +8,13 @@ Reconcile intended architecture with repository reality through deterministic to
 2. Run `validate_intent` and return `review_intent` output before downstream implementation. Route
    open ambiguities, low confidence, or `review_required` state to the approval gate.
 3. Run `generate_reality` with the absolute repository path.
-4. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
-5. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
-6. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
-7. After QA acceptance, use `promote_spec` for the exact accepted artifact.
-8. Re-run traceability validation after promotion or material state changes.
+4. Run `reconcile_dags` before diffing. Treat only identical canonical GUIDs as confirmed; exact
+   structural matches remain approval-required candidates, and unmatched Reality observations are
+   unclassified rather than deletion candidates.
+5. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
+6. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
+7. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
+8. After QA acceptance, use `promote_spec` for the exact accepted artifact.
+9. Re-run reconciliation and traceability validation after promotion or material state changes.
 
 Return a concise status, affected GUIDs and paths, drift classification, and tool output summary.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
@@ -15,6 +15,7 @@ Tool names may be namespaced by the Codex host. Match them by the operation name
 | Check PRD overlap | `check_duplicate_prd` | Use the Python API if MCP is unavailable |
 | Validate GUID links | `validate_traceability` | Use the Python API if MCP is unavailable |
 | Generate Reality DAG | `generate_reality` | `uv run dag-tool generate-reality ...` |
+| Reconcile DAG identity evidence | `reconcile_dags` | `uv run dag-tool reconcile ...` |
 | Create intent node | `create_intent_node` | `uv run dag-tool intent create-node ...` |
 | Revise Intent IR | `set_intent` | `uv run dag-tool intent set ...` |
 | Validate Intent IR | `validate_intent` | `uv run dag-tool validate-intent --file ...` |

--- a/src/aio_agentic_sdlc/dag_cli.py
+++ b/src/aio_agentic_sdlc/dag_cli.py
@@ -5,10 +5,14 @@ import click
 
 from aio_agentic_sdlc.dag_manager import DAGManager
 from aio_agentic_sdlc.dag_models import Edge, EdgeType, Node, NodeType
-from aio_agentic_sdlc.diffing_engine import DiffingEngine
+from aio_agentic_sdlc.diffing_engine import DiffingEngine, DiffPolicy
 from aio_agentic_sdlc.intent_ir import IntentIR
 from aio_agentic_sdlc.intent_store import create_intent_node_file, update_intent_file
 from aio_agentic_sdlc.reality_dag_generator import RealityDAGGenerator
+from aio_agentic_sdlc.reconciliation import (
+    ReconciliationEngine,
+    write_reconciliation_report,
+)
 
 
 @click.group()
@@ -176,17 +180,80 @@ def intent_set(file, node_id, payload_file, expected_revision):
     type=click.Path(exists=True),
     help="Path to the Reality DAG yaml file.",
 )
-def diff(intention, reality):
+@click.option(
+    "--mode",
+    type=click.Choice(["safe", "legacy-structural"]),
+    default="safe",
+    show_default=True,
+    help="Use evidence-gated planning or explicitly request legacy structural output.",
+)
+@click.option(
+    "--max-tasks",
+    type=click.IntRange(min=1),
+    default=100,
+    show_default=True,
+    help="Maximum tasks returned by safe planning.",
+)
+def diff(intention, reality, mode, max_tasks):
     """Calculates the diff between Intention DAG and Reality DAG."""
     try:
         intent_manager = DAGManager.load(intention)
         reality_manager = DAGManager.load(reality)
-        engine = DiffingEngine(intent_manager, reality_manager)
+        policy = (
+            DiffPolicy.safe(max_tasks=max_tasks)
+            if mode == "safe"
+            else DiffPolicy.legacy_structural()
+        )
+        engine = DiffingEngine(intent_manager, reality_manager, policy=policy)
         diff_result = engine.calculate_diff()
 
         click.echo(json.dumps(diff_result, indent=2))
     except Exception as e:
         click.secho(f"Error computing diff: {str(e)}", err=True, fg="red")
+        sys.exit(1)
+
+
+@cli.command("reconcile")
+@click.option(
+    "--intention",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to the canonical Intention DAG yaml file.",
+)
+@click.option(
+    "--reality",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to the generated Reality DAG yaml file.",
+)
+@click.option(
+    "--max-items",
+    type=click.IntRange(min=1),
+    default=100,
+    show_default=True,
+    help="Maximum evidence records returned without hiding complete totals.",
+)
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False),
+    help="Atomically write the JSON report instead of printing it.",
+)
+def reconcile(intention, reality, max_items, output):
+    """Render a bounded, read-only reconciliation evidence report."""
+
+    try:
+        intent_manager = DAGManager.load(intention)
+        reality_manager = DAGManager.load(reality)
+        report = ReconciliationEngine(intent_manager, reality_manager).analyze(
+            max_items=max_items
+        )
+        if output:
+            write_reconciliation_report(report, output)
+            click.echo(f"Reconciliation report saved to {output}.")
+        else:
+            click.echo(json.dumps(report, indent=2))
+    except Exception as e:
+        click.secho(f"Error reconciling DAGs: {str(e)}", err=True, fg="red")
         sys.exit(1)
 
 

--- a/src/aio_agentic_sdlc/dag_cli.py
+++ b/src/aio_agentic_sdlc/dag_cli.py
@@ -194,13 +194,23 @@ def intent_set(file, node_id, payload_file, expected_revision):
     show_default=True,
     help="Maximum tasks returned by safe planning.",
 )
-def diff(intention, reality, mode, max_tasks):
+@click.option(
+    "--max-candidates",
+    type=click.IntRange(min=1),
+    default=20,
+    show_default=True,
+    help="Maximum candidate identities retained in each safe task.",
+)
+def diff(intention, reality, mode, max_tasks, max_candidates):
     """Calculates the diff between Intention DAG and Reality DAG."""
     try:
         intent_manager = DAGManager.load(intention)
         reality_manager = DAGManager.load(reality)
         policy = (
-            DiffPolicy.safe(max_tasks=max_tasks)
+            DiffPolicy.safe(
+                max_tasks=max_tasks,
+                max_candidates=max_candidates,
+            )
             if mode == "safe"
             else DiffPolicy.legacy_structural()
         )
@@ -234,21 +244,33 @@ def diff(intention, reality, mode, max_tasks):
     help="Maximum evidence records returned without hiding complete totals.",
 )
 @click.option(
+    "--max-candidates",
+    type=click.IntRange(min=1),
+    default=20,
+    show_default=True,
+    help="Maximum candidate identities retained in each evidence record.",
+)
+@click.option(
     "--output",
     type=click.Path(dir_okay=False),
     help="Atomically write the JSON report instead of printing it.",
 )
-def reconcile(intention, reality, max_items, output):
+def reconcile(intention, reality, max_items, max_candidates, output):
     """Render a bounded, read-only reconciliation evidence report."""
 
     try:
         intent_manager = DAGManager.load(intention)
         reality_manager = DAGManager.load(reality)
         report = ReconciliationEngine(intent_manager, reality_manager).analyze(
-            max_items=max_items
+            max_items=max_items,
+            max_candidates=max_candidates,
         )
         if output:
-            write_reconciliation_report(report, output)
+            write_reconciliation_report(
+                report,
+                output,
+                protected_paths=(intention, reality),
+            )
             click.echo(f"Reconciliation report saved to {output}.")
         else:
             click.echo(json.dumps(report, indent=2))

--- a/src/aio_agentic_sdlc/diffing_engine.py
+++ b/src/aio_agentic_sdlc/diffing_engine.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal
+from uuid import UUID
 
 from aio_agentic_sdlc.dag_manager import DAGManager
 from aio_agentic_sdlc.dag_models import Edge, EdgeType
@@ -12,16 +13,32 @@ class DiffPolicy:
 
     mode: Literal["safe", "legacy_structural"] = "safe"
     max_tasks: int = 100
+    max_candidates: int = 20
 
     def __post_init__(self):
         if isinstance(self.max_tasks, bool) or not isinstance(self.max_tasks, int):
             raise TypeError("max_tasks must be an integer")
         if self.max_tasks < 1:
             raise ValueError("max_tasks must be at least 1")
+        if isinstance(self.max_candidates, bool) or not isinstance(
+            self.max_candidates, int
+        ):
+            raise TypeError("max_candidates must be an integer")
+        if self.max_candidates < 1:
+            raise ValueError("max_candidates must be at least 1")
 
     @classmethod
-    def safe(cls, *, max_tasks: int = 100) -> "DiffPolicy":
-        return cls(mode="safe", max_tasks=max_tasks)
+    def safe(
+        cls,
+        *,
+        max_tasks: int = 100,
+        max_candidates: int = 20,
+    ) -> "DiffPolicy":
+        return cls(
+            mode="safe",
+            max_tasks=max_tasks,
+            max_candidates=max_candidates,
+        )
 
     @classmethod
     def legacy_structural(cls) -> "DiffPolicy":
@@ -67,10 +84,11 @@ class DiffingEngine:
 
     def _confirmed_drift_task(self, record: Dict[str, Any]):
         intent_node = self.intention.nodes[record["intent"]["id"]]
-        reality_node = self.reality.nodes[intent_node.id]
+        reality_node = self.reality.nodes[record["reality_candidates"][0]["id"]]
         drift = []
         if (
-            reality_node.domain is not None
+            intent_node.domain is not None
+            and reality_node.domain is not None
             and intent_node.domain != reality_node.domain
         ):
             drift.append(
@@ -92,7 +110,7 @@ class DiffingEngine:
 
         name = (
             f"Update confirmed {intent_node.type.value.capitalize()} "
-            f"'{intent_node.name}' [{intent_node.id[:8]}]"
+            f"'{intent_node.name}' [{intent_node.id}]"
         )
         task = self._base_task(
             f"Node ID: {intent_node.id}\nConfirmed by canonical GUID.\n"
@@ -111,11 +129,11 @@ class DiffingEngine:
     def _review_task(self, record: Dict[str, Any]):
         intent = record["intent"]
         node_label = f"{intent['type'].capitalize()} '{intent['name']}'"
-        short_id = intent["id"][:8]
+        canonical_id = intent["id"]
         candidates = [node["id"] for node in record["reality_candidates"]]
 
         if record["classification"] == "candidate":
-            name = f"Review mapping for {node_label} [{short_id}]"
+            name = f"Review mapping for {node_label} [{canonical_id}]"
             action = "review_mapping"
             description = (
                 f"Canonical intent {intent['id']} has one deterministic structural "
@@ -123,14 +141,14 @@ class DiffingEngine:
                 "code from this evidence alone."
             )
         elif record["classification"] == "ambiguous":
-            name = f"Resolve ambiguous mapping for {node_label} [{short_id}]"
+            name = f"Resolve ambiguous mapping for {node_label} [{canonical_id}]"
             action = "resolve_ambiguous_mapping"
             description = (
                 f"Canonical intent {intent['id']} matches multiple observed nodes. "
                 "Select no mapping or exactly one mapping using additional evidence."
             )
         else:
-            name = f"Investigate implementation for {node_label} [{short_id}]"
+            name = f"Investigate implementation for {node_label} [{canonical_id}]"
             action = "investigate_intent"
             description = (
                 f"Canonical intent {intent['id']} has no deterministic structural "
@@ -145,6 +163,7 @@ class DiffingEngine:
                 "evidence": {
                     "classification": record["classification"],
                     "candidate_reality_ids": candidates,
+                    "candidate_limit": record["candidate_limit"],
                     "signals": record["evidence"],
                 },
             }
@@ -152,38 +171,69 @@ class DiffingEngine:
         return name, task
 
     def _calculate_safe(self) -> Dict[str, Any]:
-        report = ReconciliationEngine(self.intention, self.reality).analyze(
-            max_items=max(1, len(self.intention.nodes))
-        )
-        tasks = []
-        for record in report["items"]:
-            if record["subject_kind"] != "intent":
-                continue
+        engine = ReconciliationEngine(self.intention, self.reality)
+        classification_order = ("confirmed", "candidate", "ambiguous", "unmapped")
+        retained_by_classification = {
+            classification: [] for classification in classification_order
+        }
+        summary = {
+            "intention_nodes": len(self.intention.nodes),
+            "reality_nodes": len(self.reality.nodes),
+            "confirmed": 0,
+            "candidate": 0,
+            "ambiguous": 0,
+            "unmapped": 0,
+            "unclassified_reality": 0,
+        }
+        confirmed_ids = set()
+        total_tasks = 0
+        for record in engine.iter_intent_records(
+            max_candidates=self.policy.max_candidates
+        ):
+            classification = record["classification"]
+            summary[classification] += 1
+            task_entry = None
             if record["classification"] == "confirmed":
+                confirmed_ids.add(str(UUID(record["intent"]["id"])))
                 drift_task = self._confirmed_drift_task(record)
                 if drift_task:
-                    tasks.append(drift_task)
+                    task_entry = drift_task
             else:
-                tasks.append(self._review_task(record))
+                task_entry = self._review_task(record)
+            if task_entry:
+                total_tasks += 1
+                bucket = retained_by_classification[classification]
+                if len(bucket) < self.policy.max_tasks:
+                    bucket.append(task_entry)
 
-        confirmed_ids = {
-            record["intent"]["id"]
-            for record in report["items"]
-            if record["subject_kind"] == "intent"
-            and record["classification"] == "confirmed"
-        }
+        summary["unclassified_reality"] = len(self.reality.nodes) - summary["confirmed"]
+        returned = []
+        for classification in classification_order:
+            remaining = self.policy.max_tasks - len(returned)
+            if remaining == 0:
+                break
+            returned.extend(retained_by_classification[classification][:remaining])
+
         reality_edges = {
-            (edge.source, edge.target, edge.type) for edge in self.reality.edges
+            (str(UUID(edge.source)), str(UUID(edge.target)), edge.type)
+            for edge in self.reality.edges
         }
-        for edge in self.intention.edges:
-            edge_key = (edge.source, edge.target, edge.type)
+        intention_edges = {
+            (str(UUID(edge.source)), str(UUID(edge.target)), edge.type): edge
+            for edge in self.intention.edges
+        }
+        for edge_key in sorted(
+            intention_edges,
+            key=lambda key: (key[0], key[1], key[2].value),
+        ):
+            edge = intention_edges[edge_key]
             if (
-                edge.source in confirmed_ids
-                and edge.target in confirmed_ids
+                edge_key[0] in confirmed_ids
+                and edge_key[1] in confirmed_ids
                 and edge_key not in reality_edges
             ):
                 name = (
-                    f"Connect confirmed nodes '{edge.source}' to '{edge.target}' "
+                    f"Connect confirmed nodes '{edge_key[0]}' to '{edge_key[1]}' "
                     f"({edge.type.value})"
                 )
                 task = self._base_task(
@@ -194,25 +244,30 @@ class DiffingEngine:
                     {
                         "action": "connect_confirmed",
                         "evidence": {
-                            "confirmed_endpoint_ids": [edge.source, edge.target]
+                            "confirmed_endpoint_ids": [edge_key[0], edge_key[1]]
                         },
                     }
                 )
-                tasks.append((name, task))
+                total_tasks += 1
+                if len(returned) < self.policy.max_tasks:
+                    returned.append((name, task))
 
-        total_tasks = len(tasks)
-        returned = tasks[: self.policy.max_tasks]
-        nodes = {name: task for name, task in returned}
+        nodes = {}
+        for name, task in returned:
+            if name in nodes:
+                raise ValueError(f"Safe reconciliation task key collision: {name}")
+            nodes[name] = task
         return {
             "nodes": nodes,
             "edges": [],
             "meta": {
                 "mode": "safe",
                 "max_tasks": self.policy.max_tasks,
+                "max_candidates": self.policy.max_candidates,
                 "total_tasks": total_tasks,
                 "returned_tasks": len(returned),
                 "truncated": len(returned) < total_tasks,
-                "reconciliation": report["summary"],
+                "reconciliation": summary,
             },
         }
 

--- a/src/aio_agentic_sdlc/diffing_engine.py
+++ b/src/aio_agentic_sdlc/diffing_engine.py
@@ -1,7 +1,31 @@
-from typing import Any, Dict, List
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal
 
 from aio_agentic_sdlc.dag_manager import DAGManager
 from aio_agentic_sdlc.dag_models import Edge, EdgeType
+from aio_agentic_sdlc.reconciliation import ReconciliationEngine
+
+
+@dataclass(frozen=True)
+class DiffPolicy:
+    """Select safe reconciliation planning or explicit legacy structural behavior."""
+
+    mode: Literal["safe", "legacy_structural"] = "safe"
+    max_tasks: int = 100
+
+    def __post_init__(self):
+        if isinstance(self.max_tasks, bool) or not isinstance(self.max_tasks, int):
+            raise TypeError("max_tasks must be an integer")
+        if self.max_tasks < 1:
+            raise ValueError("max_tasks must be at least 1")
+
+    @classmethod
+    def safe(cls, *, max_tasks: int = 100) -> "DiffPolicy":
+        return cls(mode="safe", max_tasks=max_tasks)
+
+    @classmethod
+    def legacy_structural(cls) -> "DiffPolicy":
+        return cls(mode="legacy_structural")
 
 
 class DiffingEngine:
@@ -10,9 +34,187 @@ class DiffingEngine:
     generating a backlog of tasks required to reconcile Reality with Intention.
     """
 
-    def __init__(self, intention: DAGManager, reality: DAGManager):
+    def __init__(
+        self,
+        intention: DAGManager,
+        reality: DAGManager,
+        *,
+        policy: DiffPolicy | None = None,
+    ):
         self.intention = intention
         self.reality = reality
+        self.policy = policy or DiffPolicy.safe()
+
+    def calculate_diff(self) -> Dict[str, Any]:
+        """Calculate a bounded safe plan unless legacy behavior is explicit."""
+
+        if self.policy.mode == "legacy_structural":
+            return self._calculate_legacy_structural()
+        return self._calculate_safe()
+
+    @staticmethod
+    def _base_task(description: str) -> Dict[str, Any]:
+        return {
+            "item_type": "Task",
+            "impact": 3,
+            "effort": 2,
+            "category": "Reconciliation",
+            "description": description,
+            "status": "New",
+            "blockers": [],
+            "scores": {},
+        }
+
+    def _confirmed_drift_task(self, record: Dict[str, Any]):
+        intent_node = self.intention.nodes[record["intent"]["id"]]
+        reality_node = self.reality.nodes[intent_node.id]
+        drift = []
+        if (
+            reality_node.domain is not None
+            and intent_node.domain != reality_node.domain
+        ):
+            drift.append(
+                f"Domain drift: intention '{intent_node.domain}', "
+                f"reality '{reality_node.domain}'"
+            )
+        for key, value in (intent_node.attributes or {}).items():
+            reality_attributes = reality_node.attributes or {}
+            if key not in reality_attributes:
+                continue
+            reality_value = reality_attributes[key]
+            if reality_value != value:
+                drift.append(
+                    f"Attribute '{key}' drift: intention '{value}', "
+                    f"reality '{reality_value}'"
+                )
+        if not drift:
+            return None
+
+        name = (
+            f"Update confirmed {intent_node.type.value.capitalize()} "
+            f"'{intent_node.name}' [{intent_node.id[:8]}]"
+        )
+        task = self._base_task(
+            f"Node ID: {intent_node.id}\nConfirmed by canonical GUID.\n"
+            + "\n".join(drift)
+        )
+        task.update(
+            {
+                "category": "Maintenance",
+                "impact": 2,
+                "action": "update_confirmed",
+                "evidence": {"canonical_guid": intent_node.id},
+            }
+        )
+        return name, task
+
+    def _review_task(self, record: Dict[str, Any]):
+        intent = record["intent"]
+        node_label = f"{intent['type'].capitalize()} '{intent['name']}'"
+        short_id = intent["id"][:8]
+        candidates = [node["id"] for node in record["reality_candidates"]]
+
+        if record["classification"] == "candidate":
+            name = f"Review mapping for {node_label} [{short_id}]"
+            action = "review_mapping"
+            description = (
+                f"Canonical intent {intent['id']} has one deterministic structural "
+                "candidate. Confirm or reject the mapping; do not create or delete "
+                "code from this evidence alone."
+            )
+        elif record["classification"] == "ambiguous":
+            name = f"Resolve ambiguous mapping for {node_label} [{short_id}]"
+            action = "resolve_ambiguous_mapping"
+            description = (
+                f"Canonical intent {intent['id']} matches multiple observed nodes. "
+                "Select no mapping or exactly one mapping using additional evidence."
+            )
+        else:
+            name = f"Investigate implementation for {node_label} [{short_id}]"
+            action = "investigate_intent"
+            description = (
+                f"Canonical intent {intent['id']} has no deterministic structural "
+                "match. Establish implementation evidence before proposing creation."
+            )
+
+        task = self._base_task(description)
+        task.update(
+            {
+                "action": action,
+                "canonical_intent_id": intent["id"],
+                "evidence": {
+                    "classification": record["classification"],
+                    "candidate_reality_ids": candidates,
+                    "signals": record["evidence"],
+                },
+            }
+        )
+        return name, task
+
+    def _calculate_safe(self) -> Dict[str, Any]:
+        report = ReconciliationEngine(self.intention, self.reality).analyze(
+            max_items=max(1, len(self.intention.nodes))
+        )
+        tasks = []
+        for record in report["items"]:
+            if record["subject_kind"] != "intent":
+                continue
+            if record["classification"] == "confirmed":
+                drift_task = self._confirmed_drift_task(record)
+                if drift_task:
+                    tasks.append(drift_task)
+            else:
+                tasks.append(self._review_task(record))
+
+        confirmed_ids = {
+            record["intent"]["id"]
+            for record in report["items"]
+            if record["subject_kind"] == "intent"
+            and record["classification"] == "confirmed"
+        }
+        reality_edges = {
+            (edge.source, edge.target, edge.type) for edge in self.reality.edges
+        }
+        for edge in self.intention.edges:
+            edge_key = (edge.source, edge.target, edge.type)
+            if (
+                edge.source in confirmed_ids
+                and edge.target in confirmed_ids
+                and edge_key not in reality_edges
+            ):
+                name = (
+                    f"Connect confirmed nodes '{edge.source}' to '{edge.target}' "
+                    f"({edge.type.value})"
+                )
+                task = self._base_task(
+                    f"Both endpoints are confirmed by canonical GUID; the "
+                    f"{edge.type.value} edge is absent from Reality."
+                )
+                task.update(
+                    {
+                        "action": "connect_confirmed",
+                        "evidence": {
+                            "confirmed_endpoint_ids": [edge.source, edge.target]
+                        },
+                    }
+                )
+                tasks.append((name, task))
+
+        total_tasks = len(tasks)
+        returned = tasks[: self.policy.max_tasks]
+        nodes = {name: task for name, task in returned}
+        return {
+            "nodes": nodes,
+            "edges": [],
+            "meta": {
+                "mode": "safe",
+                "max_tasks": self.policy.max_tasks,
+                "total_tasks": total_tasks,
+                "returned_tasks": len(returned),
+                "truncated": len(returned) < total_tasks,
+                "reconciliation": report["summary"],
+            },
+        }
 
     def _is_implementation_detail(self, node_id: str) -> bool:
         visited = set()
@@ -39,7 +241,7 @@ class DiffingEngine:
 
         return check_ancestors(node_id)
 
-    def calculate_diff(self) -> Dict[str, Any]:
+    def _calculate_legacy_structural(self) -> Dict[str, Any]:
         """
         Calculates the diff between Intention DAG and Reality DAG.
         Returns a dictionary representing Backlog items.

--- a/src/aio_agentic_sdlc/mcp_server.py
+++ b/src/aio_agentic_sdlc/mcp_server.py
@@ -19,6 +19,7 @@ from .dag_manager import DAGManager
 from .dag_models import Node, NodeType
 from .intent_ir import IntentIR
 from .intent_store import create_intent_node_file, update_intent_file
+from .reconciliation import ReconciliationEngine
 from .templating_engine import generate_document as generate_document_from_template
 
 # Create the MCP server instance
@@ -338,6 +339,29 @@ def validate_traceability(
         return "Traceability Drift Detected:\n" + "\n".join(errors)
     except Exception as e:
         return f"Error validating traceability: {str(e)}"
+
+
+@mcp.tool()
+def reconcile_dags(
+    project_path: str = Field(
+        ".", description="Absolute path to the project directory"
+    ),
+    max_items: int = Field(
+        100,
+        ge=1,
+        description="Maximum evidence records returned; totals remain complete",
+    ),
+) -> str:
+    """Classify Intention/Reality identity evidence without mutating project state."""
+
+    try:
+        project_root = os.path.abspath(project_path)
+        intention = DAGManager.load(os.path.join(project_root, "intention-dag.yaml"))
+        reality = DAGManager.load(os.path.join(project_root, "reality-dag.yaml"))
+        report = ReconciliationEngine(intention, reality).analyze(max_items=max_items)
+        return json.dumps(report, indent=2)
+    except Exception as e:
+        return f"Error reconciling DAGs: {str(e)}"
 
 
 @mcp.tool()

--- a/src/aio_agentic_sdlc/mcp_server.py
+++ b/src/aio_agentic_sdlc/mcp_server.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Annotated
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -343,14 +344,23 @@ def validate_traceability(
 
 @mcp.tool()
 def reconcile_dags(
-    project_path: str = Field(
-        ".", description="Absolute path to the project directory"
-    ),
-    max_items: int = Field(
-        100,
-        ge=1,
-        description="Maximum evidence records returned; totals remain complete",
-    ),
+    project_path: Annotated[
+        str, Field(description="Absolute path to the project directory")
+    ] = ".",
+    max_items: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum evidence records returned; totals remain complete",
+        ),
+    ] = 100,
+    max_candidates: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum candidate identities retained per evidence record",
+        ),
+    ] = 20,
 ) -> str:
     """Classify Intention/Reality identity evidence without mutating project state."""
 
@@ -358,7 +368,10 @@ def reconcile_dags(
         project_root = os.path.abspath(project_path)
         intention = DAGManager.load(os.path.join(project_root, "intention-dag.yaml"))
         reality = DAGManager.load(os.path.join(project_root, "reality-dag.yaml"))
-        report = ReconciliationEngine(intention, reality).analyze(max_items=max_items)
+        report = ReconciliationEngine(intention, reality).analyze(
+            max_items=max_items,
+            max_candidates=max_candidates,
+        )
         return json.dumps(report, indent=2)
     except Exception as e:
         return f"Error reconciling DAGs: {str(e)}"

--- a/src/aio_agentic_sdlc/reconciliation.py
+++ b/src/aio_agentic_sdlc/reconciliation.py
@@ -147,7 +147,9 @@ class ReconciliationEngine:
         candidates = [
             self.reality.nodes[node_id] for node_id in candidate_ids[:max_candidates]
         ]
-        candidate_is_contested = candidate_claims[candidate_key] > 1
+        candidate_is_contested = (
+            total_candidates > 0 and candidate_claims[candidate_key] > 1
+        )
         total_contested_candidates = total_candidates if candidate_is_contested else 0
         if total_candidates == 1 and not candidate_is_contested:
             classification = "candidate"

--- a/src/aio_agentic_sdlc/reconciliation.py
+++ b/src/aio_agentic_sdlc/reconciliation.py
@@ -5,18 +5,26 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import tempfile
 import unicodedata
-from collections import Counter
+from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 from aio_agentic_sdlc.dag_manager import DAGManager
-from aio_agentic_sdlc.dag_models import Node
+from aio_agentic_sdlc.dag_models import Node, NodeType
 
 REPORT_SCHEMA_VERSION = 1
 DEFAULT_MAX_ITEMS = 100
+DEFAULT_MAX_CANDIDATES = 20
+PROTECTED_STATE_FILENAMES = {
+    "intention-dag.yaml",
+    "reality-dag.yaml",
+    "backlog.json",
+    "state-audit.jsonl",
+    "state.lock",
+}
 CLASSIFICATION_PRIORITY = {
     "confirmed": 0,
     "candidate": 1,
@@ -29,17 +37,50 @@ def normalize_node_name(value: str) -> str:
     """Return a conservative comparison key without inferring semantics."""
 
     normalized = unicodedata.normalize("NFKC", value).casefold()
-    return re.sub(r"[^a-z0-9]+", "", normalized)
+    return "".join(character for character in normalized if character.isalnum())
 
 
 def _node_summary(node: Node) -> dict[str, str]:
     return {"id": node.id, "type": node.type.value, "name": node.name}
 
 
-def write_reconciliation_report(report: dict[str, Any], output: str | Path) -> None:
+def _canonical_guid_index(
+    nodes: dict[str, Node],
+    *,
+    dag_name: str,
+) -> dict[str, str]:
+    index: dict[str, str] = {}
+    for source_id in nodes:
+        canonical_id = str(UUID(source_id))
+        if canonical_id in index:
+            raise ValueError(
+                f"{dag_name} contains duplicate canonical GUID {canonical_id}: "
+                f"{index[canonical_id]} and {source_id}"
+            )
+        index[canonical_id] = source_id
+    return index
+
+
+def write_reconciliation_report(
+    report: dict[str, Any],
+    output: str | Path,
+    *,
+    protected_paths: tuple[str | Path, ...] = (),
+) -> None:
     """Atomically persist one derived reconciliation report."""
 
     target = Path(output).resolve()
+    target_identity = os.path.normcase(str(target))
+    protected_identities = {
+        os.path.normcase(str(Path(path).resolve())) for path in protected_paths
+    }
+    if (
+        target.name.casefold() in PROTECTED_STATE_FILENAMES
+        or target_identity in protected_identities
+    ):
+        raise ValueError(
+            f"Refusing to overwrite protected framework state with a report: {target}"
+        )
     target.parent.mkdir(parents=True, exist_ok=True)
     descriptor, temporary = tempfile.mkstemp(
         dir=target.parent,
@@ -68,36 +109,49 @@ class ReconciliationEngine:
     def _intent_record(
         self,
         intent_node: Node,
-        confirmed_reality_ids: set[str],
-        candidate_claims: Counter[str],
+        confirmed_reality_by_canonical_id: dict[str, str],
+        candidate_index: dict[tuple[NodeType, str], list[str]],
+        candidate_claims: Counter[tuple[NodeType, str]],
+        max_candidates: int,
     ) -> dict[str, Any]:
-        if intent_node.id in self.reality.nodes:
-            reality_node = self.reality.nodes[intent_node.id]
+        canonical_intent_id = str(UUID(intent_node.id))
+        if canonical_intent_id in confirmed_reality_by_canonical_id:
+            reality_source_id = confirmed_reality_by_canonical_id[canonical_intent_id]
+            reality_node = self.reality.nodes[reality_source_id]
+            canonical_evidence = {
+                "kind": "canonical_guid",
+                "value": canonical_intent_id,
+            }
+            if intent_node.id != reality_source_id:
+                canonical_evidence.update(
+                    {
+                        "intent_source_id": intent_node.id,
+                        "reality_source_id": reality_source_id,
+                    }
+                )
             return {
                 "subject_kind": "intent",
                 "classification": "confirmed",
                 "intent": _node_summary(intent_node),
                 "reality_candidates": [_node_summary(reality_node)],
-                "evidence": [{"kind": "canonical_guid", "value": intent_node.id}],
+                "evidence": [canonical_evidence],
                 "requires_approval": False,
             }
 
         normalized_name = normalize_node_name(intent_node.name)
-        candidates = [
-            node
-            for node_id, node in self.reality.nodes.items()
-            if node_id not in confirmed_reality_ids
-            and node.type == intent_node.type
-            and normalize_node_name(node.name) == normalized_name
-        ]
-        candidates.sort(key=lambda node: node.id)
-
-        candidate_is_contested = any(
-            candidate_claims[node.id] > 1 for node in candidates
+        candidate_key = (intent_node.type, normalized_name)
+        candidate_ids = (
+            candidate_index.get(candidate_key, []) if normalized_name else []
         )
-        if len(candidates) == 1 and not candidate_is_contested:
+        total_candidates = len(candidate_ids)
+        candidates = [
+            self.reality.nodes[node_id] for node_id in candidate_ids[:max_candidates]
+        ]
+        candidate_is_contested = candidate_claims[candidate_key] > 1
+        total_contested_candidates = total_candidates if candidate_is_contested else 0
+        if total_candidates == 1 and not candidate_is_contested:
             classification = "candidate"
-        elif candidates:
+        elif total_candidates:
             classification = "ambiguous"
         else:
             classification = "unmapped"
@@ -115,9 +169,7 @@ class ReconciliationEngine:
             evidence.append(
                 {
                     "kind": "candidate_shared_by_multiple_intents",
-                    "reality_ids": [
-                        node.id for node in candidates if candidate_claims[node.id] > 1
-                    ],
+                    "total_shared_candidates": total_contested_candidates,
                 }
             )
 
@@ -126,91 +178,174 @@ class ReconciliationEngine:
             "classification": classification,
             "intent": _node_summary(intent_node),
             "reality_candidates": [_node_summary(node) for node in candidates],
+            "candidate_limit": {
+                "max_candidates": max_candidates,
+                "total_candidates": total_candidates,
+                "returned_candidates": len(candidates),
+                "truncated": len(candidates) < total_candidates,
+            },
             "evidence": evidence,
             "requires_approval": True,
         }
 
-    def analyze(self, *, max_items: int = DEFAULT_MAX_ITEMS) -> dict[str, Any]:
-        """Return a bounded report while retaining complete classification totals."""
+    @staticmethod
+    def _validate_limit(value: int, *, name: str) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"{name} must be an integer")
+        if value < 1:
+            raise ValueError(f"{name} must be at least 1")
 
-        if isinstance(max_items, bool) or not isinstance(max_items, int):
-            raise TypeError("max_items must be an integer")
-        if max_items < 1:
-            raise ValueError("max_items must be at least 1")
-
-        confirmed_reality_ids = set(self.intention.nodes).intersection(
-            self.reality.nodes
+    def _classification_context(self) -> dict[str, Any]:
+        intention_by_canonical_id = _canonical_guid_index(
+            self.intention.nodes,
+            dag_name="Intention DAG",
         )
-        candidate_claims: Counter[str] = Counter()
+        reality_by_canonical_id = _canonical_guid_index(
+            self.reality.nodes,
+            dag_name="Reality DAG",
+        )
+        confirmed_canonical_ids = set(intention_by_canonical_id).intersection(
+            reality_by_canonical_id
+        )
+        confirmed_reality_by_canonical_id = {
+            canonical_id: reality_by_canonical_id[canonical_id]
+            for canonical_id in confirmed_canonical_ids
+        }
+        confirmed_reality_ids = set(confirmed_reality_by_canonical_id.values())
+
+        candidate_index: dict[tuple[NodeType, str], list[str]] = defaultdict(list)
+        for node_id in sorted(self.reality.nodes):
+            if node_id in confirmed_reality_ids:
+                continue
+            node = self.reality.nodes[node_id]
+            normalized_name = normalize_node_name(node.name)
+            if normalized_name:
+                candidate_index[(node.type, normalized_name)].append(node_id)
+
+        candidate_claims: Counter[tuple[NodeType, str]] = Counter()
         for intent_node in self.intention.nodes.values():
-            if intent_node.id in confirmed_reality_ids:
+            if str(UUID(intent_node.id)) in confirmed_canonical_ids:
                 continue
             normalized_name = normalize_node_name(intent_node.name)
-            candidate_claims.update(
-                node_id
-                for node_id, node in self.reality.nodes.items()
-                if node_id not in confirmed_reality_ids
-                and node.type == intent_node.type
-                and normalize_node_name(node.name) == normalized_name
-            )
-        intent_records = [
-            self._intent_record(
+            if normalized_name:
+                candidate_claims[(intent_node.type, normalized_name)] += 1
+
+        return {
+            "confirmed_canonical_ids": confirmed_canonical_ids,
+            "confirmed_reality_by_canonical_id": confirmed_reality_by_canonical_id,
+            "candidate_index": candidate_index,
+            "candidate_claims": candidate_claims,
+        }
+
+    def _iter_intent_records(
+        self,
+        context: dict[str, Any],
+        *,
+        max_candidates: int,
+    ):
+        for node_id in sorted(self.intention.nodes):
+            yield self._intent_record(
                 self.intention.nodes[node_id],
-                confirmed_reality_ids,
-                candidate_claims,
+                context["confirmed_reality_by_canonical_id"],
+                context["candidate_index"],
+                context["candidate_claims"],
+                max_candidates,
             )
-            for node_id in sorted(self.intention.nodes)
-        ]
-        intent_records.sort(
-            key=lambda record: (
-                CLASSIFICATION_PRIORITY[record["classification"]],
-                record["intent"]["id"],
-            )
+
+    def iter_intent_records(
+        self,
+        *,
+        max_candidates: int = DEFAULT_MAX_CANDIDATES,
+    ):
+        """Yield deterministic, bounded intent records without retaining them all."""
+
+        self._validate_limit(max_candidates, name="max_candidates")
+        context = self._classification_context()
+        yield from self._iter_intent_records(
+            context,
+            max_candidates=max_candidates,
         )
-        unclassified_reality = [
-            self.reality.nodes[node_id]
-            for node_id in sorted(self.reality.nodes)
-            if node_id not in confirmed_reality_ids
-        ]
-        reality_records = [
-            {
-                "subject_kind": "reality",
-                "classification": "unclassified_reality",
-                "reality": _node_summary(node),
-                "evidence": [],
-                "requires_approval": True,
-            }
-            for node in unclassified_reality
-        ]
+
+    def analyze(
+        self,
+        *,
+        max_items: int = DEFAULT_MAX_ITEMS,
+        max_candidates: int = DEFAULT_MAX_CANDIDATES,
+    ) -> dict[str, Any]:
+        """Return a bounded report while retaining complete classification totals."""
+
+        self._validate_limit(max_items, name="max_items")
+        self._validate_limit(max_candidates, name="max_candidates")
+        context = self._classification_context()
+        classification_counts = {
+            classification: 0 for classification in CLASSIFICATION_PRIORITY
+        }
+        retained_by_classification: dict[str, list[dict[str, Any]]] = {
+            classification: [] for classification in CLASSIFICATION_PRIORITY
+        }
+        for record in self._iter_intent_records(
+            context,
+            max_candidates=max_candidates,
+        ):
+            classification = record["classification"]
+            classification_counts[classification] += 1
+            if len(retained_by_classification[classification]) < max_items:
+                retained_by_classification[classification].append(record)
+
+        intent_records: list[dict[str, Any]] = []
+        for classification in sorted(
+            CLASSIFICATION_PRIORITY,
+            key=CLASSIFICATION_PRIORITY.get,
+        ):
+            remaining = max_items - len(intent_records)
+            if remaining == 0:
+                break
+            intent_records.extend(
+                retained_by_classification[classification][:remaining]
+            )
+
+        confirmed_canonical_ids = context["confirmed_canonical_ids"]
+        confirmed_reality_ids = set(
+            context["confirmed_reality_by_canonical_id"].values()
+        )
+        unclassified_reality_count = len(self.reality.nodes) - len(
+            confirmed_canonical_ids
+        )
+        remaining = max_items - len(intent_records)
+        reality_records = []
+        if remaining:
+            for node_id in sorted(self.reality.nodes):
+                if node_id in confirmed_reality_ids:
+                    continue
+                reality_records.append(
+                    {
+                        "subject_kind": "reality",
+                        "classification": "unclassified_reality",
+                        "reality": _node_summary(self.reality.nodes[node_id]),
+                        "evidence": [],
+                        "requires_approval": True,
+                    }
+                )
+                if len(reality_records) == remaining:
+                    break
 
         summary = {
             "intention_nodes": len(self.intention.nodes),
             "reality_nodes": len(self.reality.nodes),
-            "confirmed": sum(
-                record["classification"] == "confirmed" for record in intent_records
-            ),
-            "candidate": sum(
-                record["classification"] == "candidate" for record in intent_records
-            ),
-            "ambiguous": sum(
-                record["classification"] == "ambiguous" for record in intent_records
-            ),
-            "unmapped": sum(
-                record["classification"] == "unmapped" for record in intent_records
-            ),
-            "unclassified_reality": len(unclassified_reality),
+            **classification_counts,
+            "unclassified_reality": unclassified_reality_count,
         }
         all_items = intent_records + reality_records
-        returned_items = all_items[:max_items]
+        total_items = len(self.intention.nodes) + unclassified_reality_count
 
         return {
             "schema_version": REPORT_SCHEMA_VERSION,
             "summary": summary,
             "limit": {
                 "max_items": max_items,
-                "total_items": len(all_items),
-                "returned_items": len(returned_items),
-                "truncated": len(returned_items) < len(all_items),
+                "total_items": total_items,
+                "returned_items": len(all_items),
+                "truncated": len(all_items) < total_items,
             },
-            "items": returned_items,
+            "items": all_items,
         }

--- a/src/aio_agentic_sdlc/reconciliation.py
+++ b/src/aio_agentic_sdlc/reconciliation.py
@@ -1,0 +1,216 @@
+# aio-sdlc-node: 9015c8a3-fd14-5598-916d-d03fcf41e415
+"""Deterministic, evidence-gated reconciliation of intent and observed reality."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import unicodedata
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import Node
+
+REPORT_SCHEMA_VERSION = 1
+DEFAULT_MAX_ITEMS = 100
+CLASSIFICATION_PRIORITY = {
+    "confirmed": 0,
+    "candidate": 1,
+    "ambiguous": 2,
+    "unmapped": 3,
+}
+
+
+def normalize_node_name(value: str) -> str:
+    """Return a conservative comparison key without inferring semantics."""
+
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return re.sub(r"[^a-z0-9]+", "", normalized)
+
+
+def _node_summary(node: Node) -> dict[str, str]:
+    return {"id": node.id, "type": node.type.value, "name": node.name}
+
+
+def write_reconciliation_report(report: dict[str, Any], output: str | Path) -> None:
+    """Atomically persist one derived reconciliation report."""
+
+    target = Path(output).resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+class ReconciliationEngine:
+    """Classify deterministic identity evidence without mutating either DAG."""
+
+    def __init__(self, intention: DAGManager, reality: DAGManager):
+        self.intention = intention
+        self.reality = reality
+
+    def _intent_record(
+        self,
+        intent_node: Node,
+        confirmed_reality_ids: set[str],
+        candidate_claims: Counter[str],
+    ) -> dict[str, Any]:
+        if intent_node.id in self.reality.nodes:
+            reality_node = self.reality.nodes[intent_node.id]
+            return {
+                "subject_kind": "intent",
+                "classification": "confirmed",
+                "intent": _node_summary(intent_node),
+                "reality_candidates": [_node_summary(reality_node)],
+                "evidence": [{"kind": "canonical_guid", "value": intent_node.id}],
+                "requires_approval": False,
+            }
+
+        normalized_name = normalize_node_name(intent_node.name)
+        candidates = [
+            node
+            for node_id, node in self.reality.nodes.items()
+            if node_id not in confirmed_reality_ids
+            and node.type == intent_node.type
+            and normalize_node_name(node.name) == normalized_name
+        ]
+        candidates.sort(key=lambda node: node.id)
+
+        candidate_is_contested = any(
+            candidate_claims[node.id] > 1 for node in candidates
+        )
+        if len(candidates) == 1 and not candidate_is_contested:
+            classification = "candidate"
+        elif candidates:
+            classification = "ambiguous"
+        else:
+            classification = "unmapped"
+
+        evidence: list[dict[str, Any]] = []
+        if candidates:
+            evidence.append(
+                {
+                    "kind": "normalized_name_and_type",
+                    "normalized_name": normalized_name,
+                    "node_type": intent_node.type.value,
+                }
+            )
+        if candidate_is_contested:
+            evidence.append(
+                {
+                    "kind": "candidate_shared_by_multiple_intents",
+                    "reality_ids": [
+                        node.id for node in candidates if candidate_claims[node.id] > 1
+                    ],
+                }
+            )
+
+        return {
+            "subject_kind": "intent",
+            "classification": classification,
+            "intent": _node_summary(intent_node),
+            "reality_candidates": [_node_summary(node) for node in candidates],
+            "evidence": evidence,
+            "requires_approval": True,
+        }
+
+    def analyze(self, *, max_items: int = DEFAULT_MAX_ITEMS) -> dict[str, Any]:
+        """Return a bounded report while retaining complete classification totals."""
+
+        if isinstance(max_items, bool) or not isinstance(max_items, int):
+            raise TypeError("max_items must be an integer")
+        if max_items < 1:
+            raise ValueError("max_items must be at least 1")
+
+        confirmed_reality_ids = set(self.intention.nodes).intersection(
+            self.reality.nodes
+        )
+        candidate_claims: Counter[str] = Counter()
+        for intent_node in self.intention.nodes.values():
+            if intent_node.id in confirmed_reality_ids:
+                continue
+            normalized_name = normalize_node_name(intent_node.name)
+            candidate_claims.update(
+                node_id
+                for node_id, node in self.reality.nodes.items()
+                if node_id not in confirmed_reality_ids
+                and node.type == intent_node.type
+                and normalize_node_name(node.name) == normalized_name
+            )
+        intent_records = [
+            self._intent_record(
+                self.intention.nodes[node_id],
+                confirmed_reality_ids,
+                candidate_claims,
+            )
+            for node_id in sorted(self.intention.nodes)
+        ]
+        intent_records.sort(
+            key=lambda record: (
+                CLASSIFICATION_PRIORITY[record["classification"]],
+                record["intent"]["id"],
+            )
+        )
+        unclassified_reality = [
+            self.reality.nodes[node_id]
+            for node_id in sorted(self.reality.nodes)
+            if node_id not in confirmed_reality_ids
+        ]
+        reality_records = [
+            {
+                "subject_kind": "reality",
+                "classification": "unclassified_reality",
+                "reality": _node_summary(node),
+                "evidence": [],
+                "requires_approval": True,
+            }
+            for node in unclassified_reality
+        ]
+
+        summary = {
+            "intention_nodes": len(self.intention.nodes),
+            "reality_nodes": len(self.reality.nodes),
+            "confirmed": sum(
+                record["classification"] == "confirmed" for record in intent_records
+            ),
+            "candidate": sum(
+                record["classification"] == "candidate" for record in intent_records
+            ),
+            "ambiguous": sum(
+                record["classification"] == "ambiguous" for record in intent_records
+            ),
+            "unmapped": sum(
+                record["classification"] == "unmapped" for record in intent_records
+            ),
+            "unclassified_reality": len(unclassified_reality),
+        }
+        all_items = intent_records + reality_records
+        returned_items = all_items[:max_items]
+
+        return {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "summary": summary,
+            "limit": {
+                "max_items": max_items,
+                "total_items": len(all_items),
+                "returned_items": len(returned_items),
+                "truncated": len(returned_items) < len(all_items),
+            },
+            "items": returned_items,
+        }

--- a/src/aio_agentic_sdlc/templating_engine.py
+++ b/src/aio_agentic_sdlc/templating_engine.py
@@ -48,6 +48,7 @@ def generate_document(
         loader=jinja2.FileSystemLoader(str(resolved_templates_dir)),
         autoescape=jinja2.select_autoescape(["html", "xml"]),
         undefined=jinja2.StrictUndefined,
+        keep_trailing_newline=True,
     )
 
     try:

--- a/templates/sdd-template.md
+++ b/templates/sdd-template.md
@@ -4,20 +4,27 @@ title: "{{ title }}"
 author: "{{ author }}"
 date: "{{ date }}"
 related_prd: "{{ related_prd }}"
+{% if node_id is defined %}node_id: "{{ node_id }}"
+{% endif %}
 ---
 # {{ title }}
 
 ## 1. Architecture Overview
+
 {{ architecture_overview }}
 
 ## 2. System Components
+
 {{ system_components }}
 
 ## 3. Data Model
+
 {{ data_model }}
 
 ## 4. API Design
+
 {{ api_design }}
 
 ## 5. Security Considerations
+
 {{ security_considerations }}

--- a/tests/test_dag_cli.py
+++ b/tests/test_dag_cli.py
@@ -185,3 +185,102 @@ def test_cli_edge_remove(sample_dag_file):
 
     manager = DAGManager.load(sample_dag_file)
     assert len(manager.edges) == 0
+
+
+def test_cli_reconcile_returns_bounded_read_only_report(sample_dag_file, tmp_path):
+    reality_file = tmp_path / "reality.yaml"
+    DAGManager.load(sample_dag_file).save(str(reality_file))
+    before_intention = (tmp_path / "dag.yaml").read_bytes()
+    before_reality = reality_file.read_bytes()
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reconcile",
+            "--intention",
+            sample_dag_file,
+            "--reality",
+            str(reality_file),
+            "--max-items",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    report = json.loads(result.output)
+    assert report["summary"]["confirmed"] == 2
+    assert report["limit"] == {
+        "max_items": 1,
+        "total_items": 2,
+        "returned_items": 1,
+        "truncated": True,
+    }
+    assert (tmp_path / "dag.yaml").read_bytes() == before_intention
+    assert reality_file.read_bytes() == before_reality
+
+
+def test_cli_reconcile_can_write_a_reproducible_report_artifact(
+    sample_dag_file, tmp_path
+):
+    reality_file = tmp_path / "reality.yaml"
+    report_file = tmp_path / "reconciliation-report.json"
+    DAGManager.load(sample_dag_file).save(str(reality_file))
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reconcile",
+            "--intention",
+            sample_dag_file,
+            "--reality",
+            str(reality_file),
+            "--max-items",
+            "1",
+            "--output",
+            str(report_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.output.strip() == f"Reconciliation report saved to {report_file}."
+    report = json.loads(report_file.read_text(encoding="utf-8"))
+    assert report["summary"]["confirmed"] == 2
+    assert report["limit"]["truncated"] is True
+
+
+def test_cli_diff_is_safe_by_default_and_legacy_is_explicit(sample_dag_file, tmp_path):
+    reality_file = tmp_path / "empty-reality.yaml"
+    DAGManager(Metadata(name="Reality", version="1.0"), [], []).save(str(reality_file))
+    runner = CliRunner()
+
+    safe_result = runner.invoke(
+        cli,
+        [
+            "diff",
+            "--intention",
+            sample_dag_file,
+            "--reality",
+            str(reality_file),
+        ],
+    )
+    legacy_result = runner.invoke(
+        cli,
+        [
+            "diff",
+            "--intention",
+            sample_dag_file,
+            "--reality",
+            str(reality_file),
+            "--mode",
+            "legacy-structural",
+        ],
+    )
+
+    assert safe_result.exit_code == 0
+    safe = json.loads(safe_result.output)
+    assert safe["meta"]["mode"] == "safe"
+    assert not any(name.startswith("Create ") for name in safe["nodes"])
+
+    assert legacy_result.exit_code == 0
+    legacy = json.loads(legacy_result.output)
+    assert "Create System 'System 1'" in legacy["nodes"]

--- a/tests/test_dag_cli.py
+++ b/tests/test_dag_cli.py
@@ -248,6 +248,67 @@ def test_cli_reconcile_can_write_a_reproducible_report_artifact(
     assert report["limit"]["truncated"] is True
 
 
+@pytest.mark.parametrize("protected_target", ["intention", "reality"])
+def test_cli_reconcile_refuses_to_overwrite_input_dags(
+    sample_dag_file, tmp_path, protected_target
+):
+    intention_file = tmp_path / "dag.yaml"
+    reality_file = tmp_path / "reality.yaml"
+    DAGManager.load(sample_dag_file).save(str(reality_file))
+    before_intention = intention_file.read_bytes()
+    before_reality = reality_file.read_bytes()
+    output = intention_file if protected_target == "intention" else reality_file
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reconcile",
+            "--intention",
+            str(intention_file),
+            "--reality",
+            str(reality_file),
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "protected framework state" in result.output
+    assert intention_file.read_bytes() == before_intention
+    assert reality_file.read_bytes() == before_reality
+
+
+@pytest.mark.parametrize(
+    "state_filename",
+    ["backlog.json", "state-audit.jsonl", "state.lock"],
+)
+def test_cli_reconcile_refuses_to_overwrite_versioned_state(
+    sample_dag_file, tmp_path, state_filename
+):
+    reality_file = tmp_path / "reality.yaml"
+    state_file = tmp_path / state_filename
+    DAGManager.load(sample_dag_file).save(str(reality_file))
+    state_file.write_text('{"schema_version": 2}\n', encoding="utf-8")
+    before_state = state_file.read_bytes()
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reconcile",
+            "--intention",
+            sample_dag_file,
+            "--reality",
+            str(reality_file),
+            "--output",
+            str(state_file),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "protected framework state" in result.output
+    assert state_file.read_bytes() == before_state
+
+
 def test_cli_diff_is_safe_by_default_and_legacy_is_explicit(sample_dag_file, tmp_path):
     reality_file = tmp_path / "empty-reality.yaml"
     DAGManager(Metadata(name="Reality", version="1.0"), [], []).save(str(reality_file))

--- a/tests/test_diffing_engine.py
+++ b/tests/test_diffing_engine.py
@@ -1,6 +1,6 @@
 from aio_agentic_sdlc.dag_manager import DAGManager
 from aio_agentic_sdlc.dag_models import Edge, EdgeType, Metadata, Node, NodeType
-from aio_agentic_sdlc.diffing_engine import DiffingEngine
+from aio_agentic_sdlc.diffing_engine import DiffingEngine, DiffPolicy
 
 
 def create_sample_dag(name="Sample", nodes=None, edges=None):
@@ -12,6 +12,16 @@ def create_sample_dag(name="Sample", nodes=None, edges=None):
     return DAGManager(meta, nodes, edges)
 
 
+def create_legacy_engine(intent, reality):
+    """Exercise the compatibility algorithm explicitly; safe mode is tested separately."""
+
+    return DiffingEngine(
+        intent,
+        reality,
+        policy=DiffPolicy.legacy_structural(),
+    )
+
+
 def test_missing_node():
     node_intent = Node(
         id="23608194-7147-430e-8491-f404366227c8",
@@ -21,7 +31,7 @@ def test_missing_node():
     intent = create_sample_dag(nodes=[node_intent])
     reality = create_sample_dag()
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -40,7 +50,7 @@ def test_extraneous_node():
     intent = create_sample_dag()
     reality = create_sample_dag(nodes=[node_real])
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -69,7 +79,7 @@ def test_drift_node():
     intent = create_sample_dag(nodes=[node_intent])
     reality = create_sample_dag(nodes=[node_real])
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -96,7 +106,7 @@ def test_missing_edge():
     intent = create_sample_dag(nodes=[n1, n2], edges=[edge])
     reality = create_sample_dag(nodes=[n1, n2], edges=[])
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -129,7 +139,7 @@ def test_missing_edge_with_missing_nodes():
     intent = create_sample_dag(nodes=[n1, n2], edges=[edge])
     reality = create_sample_dag()  # empty reality
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -167,7 +177,7 @@ def test_extraneous_edge():
     intent = create_sample_dag(nodes=[n1, n2], edges=[])
     reality = create_sample_dag(nodes=[n1, n2], edges=[edge])
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -192,7 +202,7 @@ def test_unmapped_node_with_no_parents():
     intent = create_sample_dag(nodes=[node_a])
     reality = create_sample_dag(nodes=[node_a, node_b])
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -218,7 +228,7 @@ def test_unmapped_node_with_unmapped_parent():
     intent = create_sample_dag(nodes=[node_a])
     reality = create_sample_dag(nodes=[node_b, node_c], edges=[edge])
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -242,7 +252,7 @@ def test_unmapped_node_with_mapped_parent():
     intent = create_sample_dag(nodes=[node_a])
     reality = create_sample_dag(nodes=[node_a, node_b], edges=[edge])
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -273,7 +283,7 @@ def test_unmapped_node_with_mapped_grandparent():
     intent = create_sample_dag(nodes=[node_a])
     reality = create_sample_dag(nodes=[node_a, node_b, node_c], edges=[edge1, edge2])
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]
@@ -313,7 +323,7 @@ def test_circular_dependency_resiliency():
         nodes=[node_b, node_c, node_d], edges=[edge1, edge2, edge3]
     )
 
-    engine = DiffingEngine(intent, reality)
+    engine = create_legacy_engine(intent, reality)
     diff = engine.calculate_diff()
 
     nodes = diff["nodes"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,7 +2,9 @@ import json
 import os
 from pathlib import Path
 
-from aio_agentic_sdlc.mcp_server import generate_document
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import Metadata, Node, NodeType
+from aio_agentic_sdlc.mcp_server import generate_document, reconcile_dags
 
 
 def test_mcp_generate_document(tmp_path):
@@ -89,3 +91,25 @@ def test_mcp_generate_document_uses_explicit_project_path(tmp_path):
     assert (project / "specs" / "generated.md").read_text(encoding="utf-8") == (
         "Project: Codex"
     )
+
+
+def test_mcp_reconcile_dags_returns_the_same_evidence_report(tmp_path):
+    node = Node(
+        id="00000000-0000-0000-0000-000000000001",
+        type=NodeType.COMPONENT,
+        name="Mapped component",
+    )
+    metadata = Metadata(name="Test", version="1.0")
+    DAGManager(metadata, [node], []).save(str(tmp_path / "intention-dag.yaml"))
+    DAGManager(metadata, [node], []).save(str(tmp_path / "reality-dag.yaml"))
+
+    result = json.loads(reconcile_dags(project_path=str(tmp_path), max_items=10))
+
+    assert result["schema_version"] == 1
+    assert result["summary"]["confirmed"] == 1
+    assert result["items"][0]["evidence"] == [
+        {
+            "kind": "canonical_guid",
+            "value": "00000000-0000-0000-0000-000000000001",
+        }
+    ]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -103,7 +103,7 @@ def test_mcp_reconcile_dags_returns_the_same_evidence_report(tmp_path):
     DAGManager(metadata, [node], []).save(str(tmp_path / "intention-dag.yaml"))
     DAGManager(metadata, [node], []).save(str(tmp_path / "reality-dag.yaml"))
 
-    result = json.loads(reconcile_dags(project_path=str(tmp_path), max_items=10))
+    result = json.loads(reconcile_dags(project_path=str(tmp_path)))
 
     assert result["schema_version"] == 1
     assert result["summary"]["confirmed"] == 1

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -168,6 +168,30 @@ def test_one_reality_candidate_cannot_be_proposed_for_multiple_intents():
     assert report["summary"]["ambiguous"] == 2
 
 
+def test_duplicate_intent_names_without_reality_do_not_invent_shared_candidates():
+    intention = _dag(
+        [
+            _node(
+                "00000000-0000-0000-0000-000000000001",
+                NodeType.COMPONENT,
+                "Worker",
+            ),
+            _node(
+                "00000000-0000-0000-0000-000000000002",
+                NodeType.COMPONENT,
+                "worker",
+            ),
+        ]
+    )
+
+    report = ReconciliationEngine(intention, _dag([])).analyze(max_items=10)
+
+    assert report["summary"]["unmapped"] == 2
+    assert all(item["classification"] == "unmapped" for item in report["items"])
+    assert all(item["reality_candidates"] == [] for item in report["items"])
+    assert all(item["evidence"] == [] for item in report["items"])
+
+
 def test_reconciliation_preserves_unicode_identity_and_rejects_empty_keys():
     japanese_intent_id = "00000000-0000-0000-0000-000000000001"
     punctuation_intent_id = "00000000-0000-0000-0000-000000000002"

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,13 +1,15 @@
 import copy
 
+import pytest
+
 from aio_agentic_sdlc.dag_manager import DAGManager
-from aio_agentic_sdlc.dag_models import Metadata, Node, NodeType
+from aio_agentic_sdlc.dag_models import Edge, EdgeType, Metadata, Node, NodeType
 from aio_agentic_sdlc.diffing_engine import DiffingEngine, DiffPolicy
 from aio_agentic_sdlc.reconciliation import ReconciliationEngine
 
 
-def _dag(nodes):
-    return DAGManager(Metadata(name="Test", version="1.0"), nodes, [])
+def _dag(nodes, edges=None):
+    return DAGManager(Metadata(name="Test", version="1.0"), nodes, edges or [])
 
 
 def _node(node_id, node_type, name):
@@ -166,6 +168,122 @@ def test_one_reality_candidate_cannot_be_proposed_for_multiple_intents():
     assert report["summary"]["ambiguous"] == 2
 
 
+def test_reconciliation_preserves_unicode_identity_and_rejects_empty_keys():
+    japanese_intent_id = "00000000-0000-0000-0000-000000000001"
+    punctuation_intent_id = "00000000-0000-0000-0000-000000000002"
+    intention = _dag(
+        [
+            _node(japanese_intent_id, NodeType.COMPONENT, "東京"),
+            _node(punctuation_intent_id, NodeType.COMPONENT, "---"),
+        ]
+    )
+    reality = _dag(
+        [
+            _node(
+                "00000000-0000-0000-0000-000000000101",
+                NodeType.COMPONENT,
+                "北京",
+            ),
+            _node(
+                "00000000-0000-0000-0000-000000000102",
+                NodeType.COMPONENT,
+                "...",
+            ),
+        ]
+    )
+
+    report = ReconciliationEngine(intention, reality).analyze(max_items=10)
+
+    by_intent = {
+        item["intent"]["id"]: item
+        for item in report["items"]
+        if item["subject_kind"] == "intent"
+    }
+    assert by_intent[japanese_intent_id]["classification"] == "unmapped"
+    assert by_intent[punctuation_intent_id]["classification"] == "unmapped"
+    assert all(not item["reality_candidates"] for item in by_intent.values())
+    assert report["summary"]["candidate"] == 0
+    assert report["summary"]["ambiguous"] == 0
+
+
+def test_reconciliation_bounds_nested_ambiguous_evidence_with_complete_totals():
+    intent_id = "00000000-0000-0000-0000-000000000001"
+    intention = _dag([_node(intent_id, NodeType.COMPONENT, "Worker")])
+    reality = _dag(
+        [
+            _node(
+                f"00000000-0000-0000-0000-{index:012d}",
+                NodeType.COMPONENT,
+                "Worker",
+            )
+            for index in range(100, 200)
+        ]
+    )
+
+    report = ReconciliationEngine(intention, reality).analyze(
+        max_items=1,
+        max_candidates=3,
+    )
+
+    item = report["items"][0]
+    assert item["classification"] == "ambiguous"
+    assert len(item["reality_candidates"]) == 3
+    assert item["candidate_limit"] == {
+        "max_candidates": 3,
+        "total_candidates": 100,
+        "returned_candidates": 3,
+        "truncated": True,
+    }
+
+    diff = DiffingEngine(
+        intention,
+        reality,
+        policy=DiffPolicy.safe(max_tasks=1, max_candidates=2),
+    ).calculate_diff()
+    task = next(iter(diff["nodes"].values()))
+    assert len(task["evidence"]["candidate_reality_ids"]) == 2
+    assert task["evidence"]["candidate_limit"]["total_candidates"] == 100
+    assert task["evidence"]["candidate_limit"]["truncated"] is True
+
+
+def test_reconciliation_confirms_mixed_case_text_forms_of_the_same_guid():
+    intent_id = "ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEFAB"
+    reality_id = intent_id.lower()
+    intention = _dag([_node(intent_id, NodeType.COMPONENT, "Intent name")])
+    reality = _dag([_node(reality_id, NodeType.COMPONENT, "Reality name")])
+
+    report = ReconciliationEngine(intention, reality).analyze(max_items=10)
+
+    assert report["summary"]["confirmed"] == 1
+    assert report["summary"]["candidate"] == 0
+    item = report["items"][0]
+    assert item["classification"] == "confirmed"
+    assert item["intent"]["id"] == intent_id
+    assert item["reality_candidates"][0]["id"] == reality_id
+    assert item["evidence"] == [
+        {
+            "kind": "canonical_guid",
+            "value": reality_id,
+            "intent_source_id": intent_id,
+            "reality_source_id": reality_id,
+        }
+    ]
+
+
+def test_reconciliation_rejects_duplicate_text_forms_of_one_canonical_guid():
+    lower_id = "abcdefab-cdef-abcd-efab-cdefabcdefab"
+    upper_id = lower_id.upper()
+    intention = _dag(
+        [
+            _node(lower_id, NodeType.COMPONENT, "First"),
+            _node(upper_id, NodeType.COMPONENT, "Duplicate"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="duplicate canonical GUID"):
+        ReconciliationEngine(intention, _dag([])).analyze(max_items=10)
+
+
 def test_safe_diff_requests_review_and_never_infers_creation_or_deletion():
     intent_id = "00000000-0000-0000-0000-000000000001"
     reality_id = "00000000-0000-0000-0000-000000000101"
@@ -184,7 +302,8 @@ def test_safe_diff_requests_review_and_never_infers_creation_or_deletion():
     diff = DiffingEngine(intention, reality).calculate_diff()
 
     assert list(diff["nodes"]) == [
-        "Review mapping for Component 'Diffing Engine' [00000000]"
+        "Review mapping for Component 'Diffing Engine' "
+        "[00000000-0000-0000-0000-000000000001]"
     ]
     task = next(iter(diff["nodes"].values()))
     assert task["category"] == "Reconciliation"
@@ -218,6 +337,7 @@ def test_safe_diff_caps_review_work_and_preserves_complete_counts():
     assert diff["meta"] == {
         "mode": "safe",
         "max_tasks": 2,
+        "max_candidates": 20,
         "total_tasks": 4,
         "returned_tasks": 2,
         "truncated": True,
@@ -231,6 +351,99 @@ def test_safe_diff_caps_review_work_and_preserves_complete_counts():
             "unclassified_reality": 0,
         },
     }
+
+
+def test_safe_diff_task_keys_cannot_drop_intents_with_shared_id_prefixes():
+    first_id = "12345678-0000-0000-0000-000000000001"
+    second_id = "12345678-0000-0000-0000-000000000002"
+    intention = _dag(
+        [
+            _node(first_id, NodeType.COMPONENT, "Same name"),
+            _node(second_id, NodeType.COMPONENT, "Same name"),
+        ]
+    )
+
+    diff = DiffingEngine(intention, _dag([])).calculate_diff()
+
+    assert len(diff["nodes"]) == 2
+    assert diff["meta"]["total_tasks"] == 2
+    assert diff["meta"]["returned_tasks"] == len(diff["nodes"])
+    assert diff["meta"]["truncated"] is False
+    assert all(node_id in "\n".join(diff["nodes"]) for node_id in (first_id, second_id))
+
+
+def test_safe_diff_canonicalizes_equivalent_mixed_case_edges():
+    first_intent_id = "ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEF01"
+    second_intent_id = "ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEF02"
+    first_reality_id = first_intent_id.lower()
+    second_reality_id = second_intent_id.lower()
+    intention = _dag(
+        [
+            _node(first_intent_id, NodeType.COMPONENT, "First"),
+            _node(second_intent_id, NodeType.COMPONENT, "Second"),
+        ],
+        [Edge(source=first_intent_id, target=second_intent_id, type=EdgeType.CALLS)],
+    )
+    reality = _dag(
+        [
+            _node(first_reality_id, NodeType.COMPONENT, "First observed"),
+            _node(second_reality_id, NodeType.COMPONENT, "Second observed"),
+        ],
+        [Edge(source=first_reality_id, target=second_reality_id, type=EdgeType.CALLS)],
+    )
+
+    diff = DiffingEngine(intention, reality).calculate_diff()
+
+    assert diff["nodes"] == {}
+    assert diff["meta"]["reconciliation"]["confirmed"] == 2
+
+
+def test_safe_diff_deduplicates_identical_logical_edges():
+    first_id = "00000000-0000-0000-0000-000000000001"
+    second_id = "00000000-0000-0000-0000-000000000002"
+    nodes = [
+        _node(first_id, NodeType.COMPONENT, "First"),
+        _node(second_id, NodeType.COMPONENT, "Second"),
+    ]
+    duplicate_edge = Edge(source=first_id, target=second_id, type=EdgeType.CALLS)
+    intention = _dag(nodes, [duplicate_edge, duplicate_edge.model_copy()])
+    reality = _dag(nodes)
+
+    diff = DiffingEngine(intention, reality).calculate_diff()
+
+    assert len(diff["nodes"]) == 1
+    assert diff["meta"]["total_tasks"] == 1
+    assert diff["meta"]["returned_tasks"] == 1
+
+
+def test_safe_diff_bounds_edges_in_canonical_order_not_input_order():
+    node_ids = [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+        "00000000-0000-0000-0000-000000000003",
+    ]
+    nodes = [
+        _node(node_id, NodeType.COMPONENT, f"Node {index}")
+        for index, node_id in enumerate(node_ids)
+    ]
+    first_edge = Edge(source=node_ids[0], target=node_ids[1], type=EdgeType.CALLS)
+    second_edge = Edge(source=node_ids[0], target=node_ids[2], type=EdgeType.CALLS)
+    reality = _dag(nodes)
+
+    first = DiffingEngine(
+        _dag(nodes, [first_edge, second_edge]),
+        reality,
+        policy=DiffPolicy.safe(max_tasks=1),
+    ).calculate_diff()
+    second = DiffingEngine(
+        _dag(nodes, [second_edge, first_edge]),
+        reality,
+        policy=DiffPolicy.safe(max_tasks=1),
+    ).calculate_diff()
+
+    assert first == second
+    assert first["meta"]["total_tasks"] == 2
+    assert first["meta"]["truncated"] is True
 
 
 def test_safe_diff_prioritizes_actionable_candidates_before_unmapped_intent():
@@ -284,6 +497,26 @@ def test_safe_diff_does_not_treat_missing_observations_as_drift():
         ]
     )
     reality = _dag([_node(node_id, NodeType.COMPONENT, "Mapped")])
+
+    diff = DiffingEngine(intention, reality).calculate_diff()
+
+    assert diff["nodes"] == {}
+    assert diff["meta"]["reconciliation"]["confirmed"] == 1
+
+
+def test_safe_diff_does_not_treat_unspecified_intent_domain_as_drift():
+    node_id = "00000000-0000-0000-0000-000000000001"
+    intention = _dag([_node(node_id, NodeType.COMPONENT, "Mapped")])
+    reality = _dag(
+        [
+            Node(
+                id=node_id,
+                type=NodeType.COMPONENT,
+                name="Mapped",
+                domain="observed",
+            )
+        ]
+    )
 
     diff = DiffingEngine(intention, reality).calculate_diff()
 

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,0 +1,360 @@
+import copy
+
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import Metadata, Node, NodeType
+from aio_agentic_sdlc.diffing_engine import DiffingEngine, DiffPolicy
+from aio_agentic_sdlc.reconciliation import ReconciliationEngine
+
+
+def _dag(nodes):
+    return DAGManager(Metadata(name="Test", version="1.0"), nodes, [])
+
+
+def _node(node_id, node_type, name):
+    return Node(id=node_id, type=node_type, name=name)
+
+
+def test_reconciliation_classifies_identity_without_inventing_mappings():
+    confirmed_id = "00000000-0000-0000-0000-000000000001"
+    unique_intent_id = "00000000-0000-0000-0000-000000000002"
+    unique_reality_id = "00000000-0000-0000-0000-000000000102"
+    ambiguous_intent_id = "00000000-0000-0000-0000-000000000003"
+    unmatched_intent_id = "00000000-0000-0000-0000-000000000004"
+
+    intention = _dag(
+        [
+            _node(confirmed_id, NodeType.COMPONENT, "Confirmed"),
+            _node(unique_intent_id, NodeType.COMPONENT, "Diffing Engine"),
+            _node(ambiguous_intent_id, NodeType.COMPONENT, "Worker"),
+            _node(unmatched_intent_id, NodeType.ENTITY, "Configuration"),
+        ]
+    )
+    reality = _dag(
+        [
+            _node(confirmed_id, NodeType.COMPONENT, "Renamed Confirmed"),
+            _node(unique_reality_id, NodeType.COMPONENT, "DiffingEngine"),
+            _node(
+                "00000000-0000-0000-0000-000000000103",
+                NodeType.COMPONENT,
+                "Worker",
+            ),
+            _node(
+                "00000000-0000-0000-0000-000000000104",
+                NodeType.COMPONENT,
+                "worker",
+            ),
+            _node(
+                "00000000-0000-0000-0000-000000000105",
+                NodeType.COMPONENT,
+                "Configuration",
+            ),
+        ]
+    )
+    before_intention = copy.deepcopy(intention)
+    before_reality = copy.deepcopy(reality)
+
+    report = ReconciliationEngine(intention, reality).analyze(max_items=100)
+
+    by_intent = {
+        item["intent"]["id"]: item
+        for item in report["items"]
+        if item["subject_kind"] == "intent"
+    }
+    assert by_intent[confirmed_id]["classification"] == "confirmed"
+    assert by_intent[confirmed_id]["requires_approval"] is False
+    assert by_intent[confirmed_id]["evidence"] == [
+        {"kind": "canonical_guid", "value": confirmed_id}
+    ]
+
+    candidate = by_intent[unique_intent_id]
+    assert candidate["classification"] == "candidate"
+    assert candidate["requires_approval"] is True
+    assert [node["id"] for node in candidate["reality_candidates"]] == [
+        unique_reality_id
+    ]
+    assert candidate["evidence"] == [
+        {
+            "kind": "normalized_name_and_type",
+            "normalized_name": "diffingengine",
+            "node_type": "component",
+        }
+    ]
+
+    ambiguous = by_intent[ambiguous_intent_id]
+    assert ambiguous["classification"] == "ambiguous"
+    assert len(ambiguous["reality_candidates"]) == 2
+    assert by_intent[unmatched_intent_id]["classification"] == "unmapped"
+
+    assert report["summary"] == {
+        "intention_nodes": 4,
+        "reality_nodes": 5,
+        "confirmed": 1,
+        "candidate": 1,
+        "ambiguous": 1,
+        "unmapped": 1,
+        "unclassified_reality": 4,
+    }
+    assert intention.nodes == before_intention.nodes
+    assert intention.edges == before_intention.edges
+    assert reality.nodes == before_reality.nodes
+    assert reality.edges == before_reality.edges
+
+
+def test_reconciliation_output_is_deterministic_and_bounded_without_hiding_totals():
+    intention = _dag(
+        [
+            _node(
+                f"00000000-0000-0000-0000-00000000000{index}",
+                NodeType.COMPONENT,
+                f"Intent {index}",
+            )
+            for index in range(1, 5)
+        ]
+    )
+    reality = _dag([])
+    engine = ReconciliationEngine(intention, reality)
+
+    first = engine.analyze(max_items=2)
+    second = engine.analyze(max_items=2)
+
+    assert first == second
+    assert first["summary"]["unmapped"] == 4
+    assert first["limit"] == {
+        "max_items": 2,
+        "total_items": 4,
+        "returned_items": 2,
+        "truncated": True,
+    }
+    assert [item["intent"]["id"] for item in first["items"]] == [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+    ]
+
+
+def test_one_reality_candidate_cannot_be_proposed_for_multiple_intents():
+    intention = _dag(
+        [
+            _node(
+                "00000000-0000-0000-0000-000000000001",
+                NodeType.COMPONENT,
+                "Worker",
+            ),
+            _node(
+                "00000000-0000-0000-0000-000000000002",
+                NodeType.COMPONENT,
+                "worker",
+            ),
+        ]
+    )
+    shared_reality_id = "00000000-0000-0000-0000-000000000101"
+    reality = _dag([_node(shared_reality_id, NodeType.COMPONENT, "Worker")])
+
+    report = ReconciliationEngine(intention, reality).analyze(max_items=10)
+
+    intent_items = [
+        item for item in report["items"] if item["subject_kind"] == "intent"
+    ]
+    assert [item["classification"] for item in intent_items] == [
+        "ambiguous",
+        "ambiguous",
+    ]
+    assert all(
+        item["reality_candidates"][0]["id"] == shared_reality_id
+        for item in intent_items
+    )
+    assert report["summary"]["candidate"] == 0
+    assert report["summary"]["ambiguous"] == 2
+
+
+def test_safe_diff_requests_review_and_never_infers_creation_or_deletion():
+    intent_id = "00000000-0000-0000-0000-000000000001"
+    reality_id = "00000000-0000-0000-0000-000000000101"
+    intention = _dag([_node(intent_id, NodeType.COMPONENT, "Diffing Engine")])
+    reality = _dag(
+        [
+            _node(reality_id, NodeType.COMPONENT, "DiffingEngine"),
+            _node(
+                "00000000-0000-0000-0000-000000000102",
+                NodeType.MODULE,
+                "Unrelated module",
+            ),
+        ]
+    )
+
+    diff = DiffingEngine(intention, reality).calculate_diff()
+
+    assert list(diff["nodes"]) == [
+        "Review mapping for Component 'Diffing Engine' [00000000]"
+    ]
+    task = next(iter(diff["nodes"].values()))
+    assert task["category"] == "Reconciliation"
+    assert task["action"] == "review_mapping"
+    assert task["evidence"]["candidate_reality_ids"] == [reality_id]
+    assert not any(
+        name.startswith(("Create ", "Remove ", "Disconnect ")) for name in diff["nodes"]
+    )
+    assert diff["meta"]["reconciliation"]["unclassified_reality"] == 2
+
+
+def test_safe_diff_caps_review_work_and_preserves_complete_counts():
+    intention = _dag(
+        [
+            _node(
+                f"00000000-0000-0000-0000-00000000000{index}",
+                NodeType.COMPONENT,
+                f"Missing {index}",
+            )
+            for index in range(1, 5)
+        ]
+    )
+
+    diff = DiffingEngine(
+        intention,
+        _dag([]),
+        policy=DiffPolicy.safe(max_tasks=2),
+    ).calculate_diff()
+
+    assert len(diff["nodes"]) == 2
+    assert diff["meta"] == {
+        "mode": "safe",
+        "max_tasks": 2,
+        "total_tasks": 4,
+        "returned_tasks": 2,
+        "truncated": True,
+        "reconciliation": {
+            "intention_nodes": 4,
+            "reality_nodes": 0,
+            "confirmed": 0,
+            "candidate": 0,
+            "ambiguous": 0,
+            "unmapped": 4,
+            "unclassified_reality": 0,
+        },
+    }
+
+
+def test_safe_diff_prioritizes_actionable_candidates_before_unmapped_intent():
+    intention = _dag(
+        [
+            _node(
+                "00000000-0000-0000-0000-000000000001",
+                NodeType.COMPONENT,
+                "Unknown implementation",
+            ),
+            _node(
+                "00000000-0000-0000-0000-000000000002",
+                NodeType.COMPONENT,
+                "Diffing Engine",
+            ),
+        ]
+    )
+    reality = _dag(
+        [
+            _node(
+                "00000000-0000-0000-0000-000000000102",
+                NodeType.COMPONENT,
+                "DiffingEngine",
+            )
+        ]
+    )
+
+    diff = DiffingEngine(
+        intention,
+        reality,
+        policy=DiffPolicy.safe(max_tasks=1),
+    ).calculate_diff()
+
+    task = next(iter(diff["nodes"].values()))
+    assert task["action"] == "review_mapping"
+    assert diff["meta"]["total_tasks"] == 2
+    assert diff["meta"]["truncated"] is True
+
+
+def test_safe_diff_does_not_treat_missing_observations_as_drift():
+    node_id = "00000000-0000-0000-0000-000000000001"
+    intention = _dag(
+        [
+            Node(
+                id=node_id,
+                type=NodeType.COMPONENT,
+                name="Mapped",
+                domain="verification",
+                attributes={"runtime": "python"},
+            )
+        ]
+    )
+    reality = _dag([_node(node_id, NodeType.COMPONENT, "Mapped")])
+
+    diff = DiffingEngine(intention, reality).calculate_diff()
+
+    assert diff["nodes"] == {}
+    assert diff["meta"]["reconciliation"]["confirmed"] == 1
+
+
+def test_safe_diff_reports_observed_contradictions_for_confirmed_identity():
+    node_id = "00000000-0000-0000-0000-000000000001"
+    intention = _dag(
+        [
+            Node(
+                id=node_id,
+                type=NodeType.COMPONENT,
+                name="Mapped",
+                domain="verification",
+                attributes={"runtime": "python"},
+            )
+        ]
+    )
+    reality = _dag(
+        [
+            Node(
+                id=node_id,
+                type=NodeType.COMPONENT,
+                name="Mapped",
+                domain="legacy",
+                attributes={"runtime": "javascript"},
+            )
+        ]
+    )
+
+    diff = DiffingEngine(intention, reality).calculate_diff()
+
+    task = next(iter(diff["nodes"].values()))
+    assert task["action"] == "update_confirmed"
+    assert (
+        "Domain drift: intention 'verification', reality 'legacy'"
+        in task["description"]
+    )
+    assert (
+        "Attribute 'runtime' drift: intention 'python', reality 'javascript'"
+        in task["description"]
+    )
+
+
+def test_legacy_structural_diff_requires_explicit_policy():
+    intent = _dag(
+        [
+            _node(
+                "00000000-0000-0000-0000-000000000001",
+                NodeType.COMPONENT,
+                "Missing",
+            )
+        ]
+    )
+    reality = _dag(
+        [
+            _node(
+                "00000000-0000-0000-0000-000000000101",
+                NodeType.COMPONENT,
+                "Extraneous",
+            )
+        ]
+    )
+
+    diff = DiffingEngine(
+        intent,
+        reality,
+        policy=DiffPolicy.legacy_structural(),
+    ).calculate_diff()
+
+    assert "Create Component 'Missing'" in diff["nodes"]
+    assert "Remove Component 'Extraneous'" in diff["nodes"]

--- a/tests/test_templating_engine.py
+++ b/tests/test_templating_engine.py
@@ -47,3 +47,22 @@ def test_template_not_found(tmp_path):
             generate_document("missing.md", {}, "out.md")
     finally:
         os.chdir(old_cwd)
+
+
+def test_generate_document_preserves_template_trailing_newline(tmp_path):
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "report.md").write_text(
+        "# {{ title }}\n",
+        encoding="utf-8",
+    )
+
+    rendered = generate_document(
+        "report.md",
+        {"title": "Evidence"},
+        str(tmp_path / "report.md"),
+        templates_dir=str(templates_dir),
+    )
+
+    assert rendered == "# Evidence\n"
+    assert (tmp_path / "report.md").read_bytes().endswith(b"\n")


### PR DESCRIPTION
## Summary

- add canonical Intent IR node `9015c8a3-fd14-5598-916d-d03fcf41e415` with a generated micro-spec and reproducible dogfood evidence
- classify canonical GUID identity, unique structural candidates, ambiguous mappings, unmapped intent, and unclassified Reality observations without mutation
- canonicalize GUID values and edge endpoints while preserving original source IDs; fail closed on duplicate canonical identity
- preserve Unicode alphanumerics and reject empty structural comparison keys
- bound report rows, nested candidate evidence, and safe tasks with complete totals and truncation metadata
- deduplicate and canonically order safe edge work, and use collision-free task identities
- prevent report output from replacing DAG, backlog, audit-journal, or lock state
- retain legacy structural output only through explicit `legacy-structural` mode
- expose equivalent read-only reports through `dag-tool reconcile` and the `reconcile_dags` MCP tool

## Dogfood result

The checked-in report is generated from the canonical committed `intention-dag.yaml` and `reality-dag.yaml` inputs with:

```powershell
uv run --no-sync dag-tool reconcile --intention intention-dag.yaml --reality reality-dag.yaml --max-items 10 --max-candidates 20
```

It reports 56 Intention nodes, 3,508 Reality nodes, 0 confirmed GUIDs, 4 deterministic candidates, 2 ambiguous intents, 50 unmapped intents, and 3,508 unclassified Reality observations. A second generation produced the same SHA-256 (`836F3E779F8BD6CE6779CEFBF49845436C61F1654E428662EC522B43BA54CFD9`). Safe planning reports 56 review/investigation tasks, returns the configured bounded subset, and emits no create, remove, or disconnect actions. The previous raw structural diff produced 6,653 operations.

The zero confirmed result is intentional evidence of the next recovery gap: canonical mapping approval and Reality identity propagation have not happened yet.

## Compatibility

`dag-tool diff` is now safe by default. Callers that intentionally need the former raw structural algorithm must pass `--mode legacy-structural`.

## Validation

- `uv sync --frozen --group dev`
- `uv run --no-sync pytest -W error` (200 passed)
- pinned Ruff 0.6.2 and Black 24.8.0
- Markdownlint (0 issues)
- `uv build`
- `uv lock --check`
- canonical Intention and Reality DAG structural validation
- partial Intent IR validation during legacy migration
- manage-sdlc skill validator
- Codex plugin validator
- dogfood report byte-for-byte reproducibility check
- `git diff --check`
