### PR TITLE
fix: patch js-yaml denial of service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
-        "@commitlint/config-conventional": "^21.0.2"
+        "@commitlint/config-conventional": "^21.0.2",
+        "husky": "^9.1.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -673,6 +674,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -758,9 +775,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",
-    "@commitlint/config-conventional": "^21.0.2"
+    "@commitlint/config-conventional": "^21.0.2",
+    "husky": "^9.1.7"
   },
   "scripts": {
     "prepare": "husky"


### PR DESCRIPTION
## Summary

- update transitive development dependency `js-yaml` from 4.3.0 to patched 4.3.1
- resolve GHSA-5p4m-2wfm-xmqj, a high-severity quadratic CPU denial of service in `!!omap` parsing
- declare Husky 9.1.7, which the tracked `prepare` script and `.husky/commit-msg` hook already require, so clean Node installs complete successfully

## Dependency path

`@commitlint/cli` → `@commitlint/load` → `cosmiconfig` → `js-yaml`

## Validation

- `npm ci`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `npm ls husky js-yaml --all`
- Prettier check for `package.json` and `package-lock.json`
- commitlint smoke test
- `uv sync --frozen --group dev`
- `uv run --no-sync pytest -W error -q` (240 passed)
- `uv lock --check`
- `git diff --check`

Closes GHSA-5p4m-2wfm-xmqj / Dependabot alert #10.
