### PR TITLE
feat(mapping): add human-readable decision briefs

### DIFF
--- a/.aio-agentic-sdlc/changes/human-readable-mapping-review/reconciliation.json
+++ b/.aio-agentic-sdlc/changes/human-readable-mapping-review/reconciliation.json
@@ -1,0 +1,275 @@
+{
+  "schema_version": 1,
+  "summary": {
+    "intention_nodes": 59,
+    "reality_nodes": 588,
+    "confirmed": 3,
+    "candidate": 5,
+    "ambiguous": 0,
+    "unmapped": 51,
+    "unclassified_reality": 585
+  },
+  "limit": {
+    "max_items": 10,
+    "total_items": 644,
+    "returned_items": 10,
+    "truncated": true
+  },
+  "items": [
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "6317643a-a8fc-5026-b373-9330004bc90d",
+        "type": "component",
+        "name": "Approval-Gated Source Mapping"
+      },
+      "reality_candidates": [
+        {
+          "id": "6317643a-a8fc-5026-b373-9330004bc90d",
+          "type": "component",
+          "name": "MappingEngine"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "6317643a-a8fc-5026-b373-9330004bc90d"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "6506870b-b262-4f54-b6e9-43de4a873a55",
+        "type": "component",
+        "name": "PRD Archiver"
+      },
+      "reality_candidates": [
+        {
+          "id": "6506870b-b262-4f54-b6e9-43de4a873a55",
+          "type": "component",
+          "name": "PRDArchiver"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "6506870b-b262-4f54-b6e9-43de4a873a55"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+        "type": "component",
+        "name": "Evidence-Gated Reconciliation Baseline"
+      },
+      "reality_candidates": [
+        {
+          "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+          "type": "module",
+          "name": "reconciliation.py"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "9015c8a3-fd14-5598-916d-d03fcf41e415"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b",
+        "type": "component",
+        "name": "Reality DAG Generator"
+      },
+      "reality_candidates": [
+        {
+          "id": "5f9d3dc7-cd7e-5402-86cd-356a4b6846fb",
+          "type": "component",
+          "name": "RealityDAGGenerator"
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "realitydaggenerator",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "685b1d12-3eed-48f6-9fa8-b8ec88a5587f",
+        "type": "component",
+        "name": "Traceability Validator"
+      },
+      "reality_candidates": [
+        {
+          "id": "4332ee05-cded-51dc-b884-7249af9d97cd",
+          "type": "component",
+          "name": "TraceabilityValidator"
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "traceabilityvalidator",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "9865715b-99a5-4dcb-ba92-90b03cc3cf1c",
+        "type": "component",
+        "name": "Tree-Sitter Parser"
+      },
+      "reality_candidates": [
+        {
+          "id": "68d91d09-7a15-5e5c-8387-68ac2ec30139",
+          "type": "component",
+          "name": "TreeSitterParser"
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "treesitterparser",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "d0307d83-371e-4bb6-925d-84a4b70beb6b",
+        "type": "component",
+        "name": "Parser Factory"
+      },
+      "reality_candidates": [
+        {
+          "id": "a7278b66-0ac6-5e6b-91d7-0604d42cc40f",
+          "type": "component",
+          "name": "ParserFactory"
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "parserfactory",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "candidate",
+      "intent": {
+        "id": "fa35fa8a-b6b5-40ca-9080-b31421117e37",
+        "type": "component",
+        "name": "Diffing Engine"
+      },
+      "reality_candidates": [
+        {
+          "id": "6199cd62-9332-5ad1-b458-18bd2e865da1",
+          "type": "component",
+          "name": "DiffingEngine"
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
+      "evidence": [
+        {
+          "kind": "normalized_name_and_type",
+          "normalized_name": "diffingengine",
+          "node_type": "component"
+        }
+      ],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "07e7e16c-c4d7-4f59-ac98-5d33599f0270",
+        "type": "agent",
+        "name": "SDLC Architect Agent"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "09497db1-e4c8-43f3-8c27-ee8577b2b59f",
+        "type": "component",
+        "name": "TUI Dashboard"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    }
+  ]
+}

--- a/.aio-agentic-sdlc/reality-dag.yaml
+++ b/.aio-agentic-sdlc/reality-dag.yaml
@@ -608,6 +608,10 @@ nodes:
   type: module
   name: mapping.py
   description: Module src.aio_agentic_sdlc.mapping
+- id: af738342-309b-5d5a-b940-ff6b5cb50a7b
+  type: component
+  name: render_mapping_review
+  description: Render a mapping report as a human decision brief with audit data last.
 - id: 6a32e581-a47a-59f8-acb8-6b59a5020cfa
   type: component
   name: MappingError
@@ -702,7 +706,7 @@ nodes:
 - id: 93cc7cb1-efa6-5648-9b4c-1214e0602884
   type: component
   name: review_mapping
-  description: Return fresh source-bound evidence for one mapping decision.
+  description: Return a human-first decision brief plus fresh source-bound audit evidence.
 - id: ec1e27bd-46ff-5749-9218-3e302db760a9
   type: component
   name: approve_mapping
@@ -1273,6 +1277,10 @@ nodes:
   type: component
   name: test_cli_mapping_review_and_approve_use_the_same_fresh_evidence
   description: Function test_cli_mapping_review_and_approve_use_the_same_fresh_evidence
+- id: 832ab3f1-e3f9-59ec-a7cb-67c714fe36e2
+  type: component
+  name: test_cli_mapping_review_defaults_to_a_human_decision_brief
+  description: Function test_cli_mapping_review_defaults_to_a_human_decision_brief
 - id: 9ce05651-500c-5f75-9c1c-5b2b6cd17dc4
   type: component
   name: test_cli_diff_is_safe_by_default_and_legacy_is_explicit
@@ -1756,6 +1764,18 @@ nodes:
   type: component
   name: test_mapping_review_binds_fresh_candidate_to_exact_source_without_mutation
   description: Function test_mapping_review_binds_fresh_candidate_to_exact_source_without_mutation
+- id: a5a7567d-ff6c-54cf-bbd2-e369fa66f403
+  type: component
+  name: test_mapping_review_is_a_human_decision_brief_not_an_id_table
+  description: Function test_mapping_review_is_a_human_decision_brief_not_an_id_table
+- id: d0a7bfd6-3163-512f-b414-c87849929296
+  type: component
+  name: test_mapping_digest_binds_the_reviewed_intent_semantics
+  description: Function test_mapping_digest_binds_the_reviewed_intent_semantics
+- id: 5fce6668-1bc5-57dc-92d3-d543cf13010d
+  type: component
+  name: test_mapping_review_bounds_related_test_evidence
+  description: Function test_mapping_review_bounds_related_test_evidence
 - id: 49bb24d8-7a77-5a4b-b2f5-84ccf7e89a58
   type: component
   name: test_mapping_approval_atomically_marks_and_confirms_exact_python_symbol
@@ -2822,6 +2842,9 @@ edges:
   target: db87f8e5-dca8-5952-91f6-454eec0f1a34
   type: contains
 - source: db87f8e5-dca8-5952-91f6-454eec0f1a34
+  target: af738342-309b-5d5a-b940-ff6b5cb50a7b
+  type: contains
+- source: db87f8e5-dca8-5952-91f6-454eec0f1a34
   target: 6a32e581-a47a-59f8-acb8-6b59a5020cfa
   type: contains
 - source: db87f8e5-dca8-5952-91f6-454eec0f1a34
@@ -3302,6 +3325,9 @@ edges:
   target: e9194825-1bcd-5dda-95a6-ff249ad728d1
   type: contains
 - source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
+  target: 832ab3f1-e3f9-59ec-a7cb-67c714fe36e2
+  type: contains
+- source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
   target: 9ce05651-500c-5f75-9c1c-5b2b6cd17dc4
   type: contains
 - source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
@@ -3666,6 +3692,15 @@ edges:
   type: contains
 - source: 75ad0ca0-6dc2-5cfa-8c2e-eb2ebff77744
   target: 607f9d02-4c5a-5f83-a8f3-a1edba192337
+  type: contains
+- source: 75ad0ca0-6dc2-5cfa-8c2e-eb2ebff77744
+  target: a5a7567d-ff6c-54cf-bbd2-e369fa66f403
+  type: contains
+- source: 75ad0ca0-6dc2-5cfa-8c2e-eb2ebff77744
+  target: d0a7bfd6-3163-512f-b414-c87849929296
+  type: contains
+- source: 75ad0ca0-6dc2-5cfa-8c2e-eb2ebff77744
+  target: 5fce6668-1bc5-57dc-92d3-d543cf13010d
   type: contains
 - source: 75ad0ca0-6dc2-5cfa-8c2e-eb2ebff77744
   target: 49bb24d8-7a77-5a4b-b2f5-84ccf7e89a58

--- a/README.md
+++ b/README.md
@@ -169,13 +169,19 @@ Promote one unique Python class or function candidate only through an explicit t
 
 ```bash
 uv run dag-tool mapping review --project-path /absolute/project --intent-id <guid>
+# Machine consumers can request the complete report explicitly:
+uv run dag-tool mapping review --project-path /absolute/project --intent-id <guid> --format json
 uv run dag-tool mapping approve --project-path /absolute/project --intent-id <guid> \
   --candidate-reality-id <reviewed-guid> --evidence-digest <reviewed-digest> \
   --approved-by <identity> --approved-at <timezone-aware-iso8601> \
   --rationale "Why this exact source symbol implements the intent"
 ```
 
-Review regenerates Reality in memory and binds the candidate to its exact source path, symbol,
-line, and SHA-256 without changing canonical state. Approval repeats that review under a dedicated
-lock, rejects stale or ambiguous evidence, atomically inserts the canonical marker and audit
-receipt, and rolls back unless a fresh scan confirms the intended GUID at the same symbol.
+Review regenerates Reality in memory and defaults to a human decision brief. The brief puts the
+intended responsibility, acceptance criteria, relationships, implementation documentation, public
+API, and related tests ahead of GUIDs and hashes. Related tests are references, not proof; mapping
+approval links source identity and does not approve the Intent IR or claim behavioral completion.
+The machine report and its digest bind the reviewed intent semantics and the exact source evidence
+without changing canonical state. Approval repeats that review under a dedicated lock, rejects
+stale or ambiguous evidence, atomically inserts the canonical marker and audit receipt, and rolls
+back unless a fresh scan confirms the intended GUID at the same symbol.

--- a/doc/codex-plugin.md
+++ b/doc/codex-plugin.md
@@ -67,15 +67,18 @@ prompts include:
 - “Show me the highest-priority unblocked task.”
 - “Generate the Reality DAG and report traceability drift.”
 - “Reconcile the Intention and Reality DAGs without proposing destructive cleanup.”
-- “Review this unique mapping candidate and ask me to approve the exact evidence.”
+- “Show me a human-readable mapping decision brief for this candidate.”
 
 For MCP calls, pass the absolute target repository as `project_path`. This is especially important
 when the plugin is installed because Codex runs the server from a cached plugin package, not from
 the target repository.
 
 For structural candidates, the plugin separates read-only review from mutation. It must show the
-exact candidate, source location, and evidence digest, then wait for explicit human approval before
-calling `approve_mapping`. Any intervening source or evidence change invalidates that approval.
+human decision brief: intended responsibility and criteria, actual symbol documentation and public
+API, related tests, and unresolved gaps. GUIDs and the digest are audit inputs shown last, not a
+substitute for review. The default decision is defer because a structural name/type match does not
+prove responsibility or behavior. Only an explicit human identity-linkage decision permits
+`approve_mapping`; any intervening intent, source, or displayed evidence change invalidates it.
 
 ## Validate changes
 

--- a/doc/mapping-review.md
+++ b/doc/mapping-review.md
@@ -1,0 +1,42 @@
+# Human-readable mapping review
+
+Reconciliation can find an Intention node and a Reality symbol with the same normalized name and
+structural type. That narrows the search; it does not prove they have the same responsibility or
+that the implementation satisfies the intent.
+
+Run the read-only review before any identity marker is written:
+
+```powershell
+uv run dag-tool mapping review `
+  --project-path X:\absolute\project `
+  --intent-id <guid>
+```
+
+The default output is a human decision brief in this order:
+
+1. **What is intended:** responsibility, approval state, confidence, acceptance criteria, and named
+   relationships to other Intention nodes.
+2. **What exists:** exact Python class or function, source location, docstring, bases, public API,
+   and bounded test functions that contain an exact symbol reference.
+3. **What was established:** unique structural and source-location facts.
+4. **What still needs human judgment:** responsibility equivalence, behavioral evidence, each
+   unverified acceptance criterion, and open Intent IR ambiguities.
+5. **Decision choices:** approve, reject, or defer. Defer is the default.
+6. **Audit metadata:** GUIDs and the digest needed by the approval command.
+
+Related tests are discovery aids, not behavioral proof. Mapping approval means only “this exact
+source symbol is the canonical implementation identity for this Intention node.” It does not approve
+the Intent IR, close ambiguities, or mark acceptance criteria as satisfied.
+
+Use JSON only for automation or complete evidence inspection:
+
+```powershell
+uv run dag-tool mapping review `
+  --project-path X:\absolute\project `
+  --intent-id <guid> `
+  --format json
+```
+
+The evidence digest binds the full reviewed Intent semantics, the exact candidate source hash, the
+human decision brief, and displayed related-test evidence. The approval command regenerates the
+review under lock and rejects changed evidence.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
@@ -25,9 +25,12 @@ candidates, and unmatched Reality observations are unclassified rather than dele
 - Tooling drift: the framework cannot represent or detect the state; record a framework blocker.
 
 When reconciliation yields exactly one supported structural candidate, run `review_mapping` and
-ask an authorized human to accept or reject the exact candidate, source path, and evidence digest.
-Only after that explicit decision may `approve_mapping` atomically add the canonical source marker
-and audit receipt. A changed digest or source requires a new review and a new approval.
+present its human decision brief. Ask an authorized human whether the implementation responsibility,
+public surface, documentation, and related-test evidence justify linking the candidate to the
+Intention node. Structural matching and test references are not behavioral proof, so defer is the
+default. Only after an explicit identity-linkage decision may `approve_mapping` atomically add the
+canonical source marker and audit receipt. GUIDs and the digest are audit inputs, and any changed
+digest, intent, or source requires a new review and approval.
 
 ## 4. Implementation
 

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
@@ -12,10 +12,13 @@ Reconcile intended architecture with repository reality through deterministic to
    structural matches remain approval-required candidates, and unmatched Reality observations are
    unclassified rather than deletion candidates. Keep both record and nested-candidate limits
    bounded, and retain their complete totals and truncation metadata.
-5. For one unique structural candidate, run `review_mapping` and present its exact source-bound
-   evidence and digest. Call `approve_mapping` only after an authorized human explicitly approves
-   that exact candidate and supplies the approver identity, timezone-aware time, and rationale.
-   Never infer approval or approve ambiguous, unmapped, unsupported, stale, or mismatched evidence.
+5. For one unique structural candidate, run `review_mapping` and present the human decision brief:
+   intended responsibility and criteria, implementation documentation and public API, related tests,
+   and unresolved gaps. State that test references are not proof and mapping links identity rather
+   than approving behavior. Put source-bound GUIDs and the digest last as audit metadata. Call
+   `approve_mapping` only after an authorized human explicitly approves that exact identity linkage
+   and supplies the approver identity, timezone-aware time, and rationale. Never infer approval or
+   approve ambiguous, unmapped, unsupported, stale, or mismatched evidence.
 6. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
 7. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
 8. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
@@ -33,7 +33,10 @@ root so its containment checks apply to the target repository instead of the MCP
 Treat warnings and string results beginning with `Error:` as failed operations. Re-read state after
 a write before claiming success. Do not fall back to manual edits for protected state.
 
-Mapping is a two-step approval gate. Run `review_mapping` immediately before presenting a decision,
-show the exact intent, Reality candidate, source path and evidence digest, and call `approve_mapping`
-only after an authorized human explicitly accepts that exact evidence. Never approve ambiguous,
-unmapped, unsupported, stale, or mismatched evidence.
+Mapping is a two-step approval gate. Run `review_mapping` immediately before presenting a decision.
+Present the decision brief first: intended responsibility and acceptance criteria, actual symbol
+documentation and public API, related tests, and unresolved gaps. Explain that test references are
+not proof and that approval links identity rather than approving behavior. Show GUIDs and the digest
+last as audit inputs. Call `approve_mapping` only after an authorized human explicitly accepts that
+exact identity linkage. Never approve ambiguous, unmapped, unsupported, stale, or mismatched
+evidence.

--- a/src/aio_agentic_sdlc/dag_cli.py
+++ b/src/aio_agentic_sdlc/dag_cli.py
@@ -17,7 +17,11 @@ from aio_agentic_sdlc.diffing_engine import DiffingEngine, DiffPolicy
 from aio_agentic_sdlc.intent_ir import IntentIR
 from aio_agentic_sdlc.intent_migration import LegacyIntentMigrator
 from aio_agentic_sdlc.intent_store import create_intent_node_file, update_intent_file
-from aio_agentic_sdlc.mapping import MappingApproval, MappingEngine
+from aio_agentic_sdlc.mapping import (
+    MappingApproval,
+    MappingEngine,
+    render_mapping_review,
+)
 from aio_agentic_sdlc.reality_dag_generator import RealityDAGGenerator
 from aio_agentic_sdlc.reconciliation import (
     ReconciliationEngine,
@@ -368,12 +372,24 @@ def mapping():
     help="Absolute path to the project directory.",
 )
 @click.option("--intent-id", required=True, help="Canonical Intention node GUID.")
-def mapping_review(project_path, intent_id):
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["human", "json"], case_sensitive=False),
+    default="human",
+    show_default=True,
+    help="Render a decision brief for people or the complete machine report.",
+)
+def mapping_review(project_path, intent_id, output_format):
     """Render fresh source-bound evidence for one mapping decision."""
 
     try:
         engine = MappingEngine(project_path, Path(project_path) / INTENTION_DAG_FILE)
-        click.echo(json.dumps(engine.review(intent_id), indent=2))
+        report = engine.review(intent_id)
+        if output_format == "json":
+            click.echo(json.dumps(report, indent=2))
+        else:
+            click.echo(render_mapping_review(report))
     except Exception as e:
         click.secho(f"Error reviewing mapping: {str(e)}", err=True, fg="red")
         sys.exit(1)

--- a/src/aio_agentic_sdlc/mapping.py
+++ b/src/aio_agentic_sdlc/mapping.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 import os
@@ -16,6 +17,7 @@ from filelock import FileLock
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_store import guarded_directory_path, guarded_file_path
 from aio_agentic_sdlc.intent_ir import NonEmptyStr
 from aio_agentic_sdlc.reality_dag_generator import (
     IGNORED_DIRECTORIES,
@@ -34,8 +36,192 @@ from aio_agentic_sdlc.workspace import (
     workspace_migration_lock,
 )
 
-MAPPING_SCHEMA_VERSION = 1
+MAPPING_REVIEW_SCHEMA_VERSION = 2
+MAPPING_APPROVAL_SCHEMA_VERSION = 1
 SUPPORTED_SYMBOL_KINDS = {"class", "function"}
+MAX_PUBLIC_API_ITEMS = 20
+MAX_RELATED_TESTS = 10
+MAX_INTENT_RELATIONSHIPS = 20
+MAX_INTENT_DETAILS = 20
+
+
+def _bounded(items: list[dict[str, Any]], maximum: int) -> dict[str, Any]:
+    """Return deterministic bounded evidence while retaining complete totals."""
+
+    total = len(items)
+    returned = items[:maximum]
+    return {
+        "total": total,
+        "returned": len(returned),
+        "truncated": total > maximum,
+        "items": returned,
+    }
+
+
+def _display_value(value: Any, fallback: str) -> str:
+    if value is None or value == "":
+        return fallback
+    return str(value)
+
+
+def _indented_text(value: Any, fallback: str, continuation: str = "    ") -> str:
+    return _display_value(value, fallback).replace("\n", f"\n{continuation}")
+
+
+def _human_provenance_reference(reference: str) -> str:
+    if "#node:" in reference:
+        return f"{reference.split('#', 1)[0]} (node statement)"
+    if "#edge:" in reference:
+        return f"{reference.split('#', 1)[0]} (relationship statement)"
+    return reference
+
+
+def _human_evidence_reference(reference: str) -> str:
+    if reference.startswith("reconciliation:intent:"):
+        return "fresh reconciliation evidence for this intent"
+    return reference
+
+
+def render_mapping_review(report: dict[str, Any]) -> str:
+    """Render a mapping report as a human decision brief with audit data last."""
+
+    brief = report["decision_brief"]
+    intention = brief["intention"]
+    implementation = brief.get("implementation")
+    target_name = implementation["symbol"] if implementation else "no unique symbol"
+    lines = [
+        f"Mapping decision: {intention['title']} -> {target_name}",
+        "",
+        "What is intended",
+        f"  Responsibility: {intention['responsibility']}",
+        f"  Intent approval: {intention['approval_state']}",
+        f"  Confidence: {intention['confidence']}",
+    ]
+    provenance = intention["provenance"]
+    if provenance["items"]:
+        lines.append("  Intent sources:")
+        for item in provenance["items"]:
+            lines.append(
+                f"    - [{item['source_type']}] "
+                f"{_human_provenance_reference(item['reference'])}: "
+                f"{item['statement']}"
+            )
+        if provenance["truncated"]:
+            lines.append(
+                f"    - ... {provenance['total'] - provenance['returned']} more"
+            )
+    assumptions = intention["assumptions"]
+    if assumptions["items"]:
+        lines.append("  Assumptions:")
+        lines.extend(f"    - {item['statement']}" for item in assumptions["items"])
+        if assumptions["truncated"]:
+            lines.append(
+                f"    - ... {assumptions['total'] - assumptions['returned']} more"
+            )
+    criteria = intention["acceptance_criteria"]
+    if criteria["items"]:
+        lines.append("  Acceptance criteria (not verified by mapping):")
+        for index, criterion in enumerate(criteria["items"], start=1):
+            lines.append(f"    - Criterion {index}: {criterion['statement']}")
+            evidence = ", ".join(
+                _human_evidence_reference(item)
+                for item in criterion["required_evidence"]
+            )
+            lines.append(f"      Required evidence: {evidence}")
+        if criteria["truncated"]:
+            lines.append(f"    - ... {criteria['total'] - criteria['returned']} more")
+    else:
+        lines.append("  Acceptance criteria: none recorded")
+
+    relationships = intention["relationships"]
+    if relationships["items"]:
+        lines.append("  Intended relationships:")
+        for relationship in relationships["items"]:
+            description = relationship.get("description")
+            suffix = f" - {description}" if description else ""
+            lines.append(
+                "    - "
+                f"{relationship['direction']} {relationship['relationship']} "
+                f"{relationship['other']}"
+                f"{suffix}"
+            )
+        if relationships["truncated"]:
+            lines.append(
+                f"    - ... {relationships['total'] - relationships['returned']} more"
+            )
+
+    lines.extend(["", "What exists"])
+    if implementation is None:
+        lines.append("  No single supported Python source symbol was found.")
+    else:
+        lines.extend(
+            [
+                f"  Symbol: {implementation['signature']}",
+                f"  Location: {implementation['location']}",
+                "  Documentation: "
+                f"{_indented_text(implementation['docstring'], 'none')}",
+            ]
+        )
+        if implementation["bases"]:
+            lines.append(f"  Bases: {', '.join(implementation['bases'])}")
+        public_api = implementation["public_api"]
+        if public_api["items"]:
+            lines.append("  Public API:")
+            for member in public_api["items"]:
+                description = _display_value(member["docstring"], "no docstring")
+                lines.append(f"    - {member['signature']} - {description}")
+            if public_api["truncated"]:
+                lines.append(
+                    f"    - ... {public_api['total'] - public_api['returned']} more"
+                )
+        else:
+            lines.append("  Public API: no public methods detected")
+
+        related_tests = implementation["related_tests"]
+        lines.append("  Related tests (references, not proof):")
+        if related_tests["items"]:
+            for test in related_tests["items"]:
+                lines.append(f"    - {test['path']}:{test['line']} - {test['test']}")
+            if related_tests["truncated"]:
+                lines.append(
+                    f"    - ... {related_tests['total'] - related_tests['returned']} more"
+                )
+        else:
+            lines.append("    - none found by exact symbol reference")
+
+    assessment = brief["assessment"]
+    lines.extend(["", "What the tool established"])
+    for statement in assessment["established"]:
+        lines.append(f"  - {statement}")
+    lines.append("")
+    lines.append("What still needs human judgment")
+    for statement in assessment["not_established"]:
+        lines.append(f"  - {statement}")
+
+    lines.extend(
+        [
+            "",
+            "Decision choices",
+            "  APPROVE - link this Intent GUID to this exact source symbol.",
+            "  REJECT  - do not link; route the mismatch back to the Cartographer.",
+            "  DEFER   - gather better intent or implementation evidence first.",
+            "  Default: DEFER (structural matching alone is insufficient).",
+            "",
+            "Audit metadata (for approve command; not decision evidence)",
+            f"  Intent GUID: {report['intent']['id']}",
+            "  Candidate Reality GUID: "
+            + (
+                report["candidates"][0]["reality"]["id"]
+                if len(report["candidates"]) == 1
+                else "unavailable"
+            ),
+            f"  Evidence digest: {report['evidence_digest'] or 'unavailable'}",
+        ]
+    )
+    if report["approval"]["blockers"]:
+        lines.append("  Approval blockers:")
+        lines.extend(f"    - {blocker}" for blocker in report["approval"]["blockers"])
+    return "\n".join(lines)
 
 
 class MappingError(ValueError):
@@ -103,10 +289,269 @@ class MappingEngine:
                 return record
         raise MappingError(f"Intent node {canonical_intent_id} does not exist")
 
+    def _intent_node(self, intent_id: str, intention):
+        canonical_intent_id = self._canonical_guid(intent_id, label="Intent GUID")
+        for node in intention.nodes.values():
+            if str(UUID(node.id)) == canonical_intent_id:
+                return node
+        raise MappingError(f"Intent node {canonical_intent_id} does not exist")
+
     def _source_path(self, relative_path: str) -> Path:
         lexical_path = self.project_root / Path(relative_path)
         resolved_path = lexical_path.resolve()
-        return self._require_contained(resolved_path, label="Mapping source")
+        self._require_contained(resolved_path, label="Mapping source")
+        try:
+            return guarded_file_path(lexical_path)
+        except ValueError as error:
+            raise MappingError(
+                f"unsafe mapping source: {relative_path}: {error}"
+            ) from error
+
+    @staticmethod
+    def _function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+        prefix = "async " if isinstance(node, ast.AsyncFunctionDef) else ""
+        arguments = ast.unparse(node.args)
+        returns = f" -> {ast.unparse(node.returns)}" if node.returns else ""
+        return f"{prefix}{node.name}({arguments}){returns}"
+
+    @staticmethod
+    def _definition_node(tree: ast.AST, source: dict[str, Any]):
+        expected_types = (
+            (ast.ClassDef,)
+            if source["symbol_kind"] == "class"
+            else (ast.FunctionDef, ast.AsyncFunctionDef)
+        )
+        matches = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, expected_types)
+            and node.name == source["symbol_name"]
+            and node.lineno == source["definition_line"]
+        ]
+        if len(matches) != 1:
+            raise MappingError(
+                "candidate source no longer resolves to one exact Python definition"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _test_functions(tree: ast.Module):
+        def walk(nodes, prefix=""):
+            for node in nodes:
+                if isinstance(node, ast.ClassDef):
+                    yield from walk(node.body, f"{prefix}{node.name}.")
+                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if node.name.startswith("test"):
+                        yield f"{prefix}{node.name}", node
+
+        yield from walk(tree.body)
+
+    @staticmethod
+    def _references_symbol(node: ast.AST, symbol_name: str) -> bool:
+        return any(
+            (isinstance(child, ast.Name) and child.id == symbol_name)
+            or (isinstance(child, ast.Attribute) and child.attr == symbol_name)
+            for child in ast.walk(node)
+        )
+
+    def _related_tests(self, symbol_name: str) -> dict[str, Any]:
+        tests_root = self.project_root / "tests"
+        if not tests_root.exists():
+            return _bounded([], MAX_RELATED_TESTS)
+        try:
+            tests_root = guarded_directory_path(tests_root)
+        except ValueError as error:
+            raise MappingError(f"unsafe tests directory: {error}") from error
+
+        matches: list[dict[str, Any]] = []
+        total_matches = 0
+        for root, directories, filenames in os.walk(tests_root):
+            try:
+                current = guarded_directory_path(root)
+                safe_directories = []
+                for directory in sorted(directories):
+                    if directory in IGNORED_DIRECTORIES:
+                        continue
+                    guarded_directory_path(current / directory)
+                    safe_directories.append(directory)
+                directories[:] = safe_directories
+            except ValueError as error:
+                raise MappingError(f"unsafe tests directory: {error}") from error
+
+            for filename in sorted(filenames):
+                if not filename.endswith(".py"):
+                    continue
+                try:
+                    test_path = guarded_file_path(current / filename)
+                    raw_source = test_path.read_bytes()
+                    parsed = ast.parse(
+                        raw_source.decode("utf-8"), filename=str(test_path)
+                    )
+                except UnicodeDecodeError:
+                    continue
+                except SyntaxError:
+                    continue
+                except ValueError as error:
+                    raise MappingError(f"unsafe test source: {error}") from error
+
+                relative = test_path.relative_to(self.project_root).as_posix()
+                source_sha256 = hashlib.sha256(raw_source).hexdigest()
+                for test_name, test_node in self._test_functions(parsed):
+                    if self._references_symbol(test_node, symbol_name):
+                        total_matches += 1
+                        if len(matches) < MAX_RELATED_TESTS:
+                            matches.append(
+                                {
+                                    "path": relative,
+                                    "line": test_node.lineno,
+                                    "test": test_name,
+                                    "match": "exact_symbol_reference",
+                                    "source_sha256": source_sha256,
+                                }
+                            )
+
+        return {
+            "total": total_matches,
+            "returned": len(matches),
+            "truncated": total_matches > len(matches),
+            "items": matches,
+        }
+
+    def _implementation_summary(self, source: dict[str, Any]) -> dict[str, Any]:
+        source_path = self._source_path(source["path"])
+        try:
+            content = source_path.read_text(encoding="utf-8")
+            tree = ast.parse(content, filename=str(source_path))
+        except (UnicodeDecodeError, SyntaxError) as error:
+            raise MappingError(
+                f"candidate Python source cannot be inspected: {error}"
+            ) from error
+        definition = self._definition_node(tree, source)
+        decorators = [ast.unparse(item) for item in definition.decorator_list]
+        bases: list[str] = []
+        public_members: list[dict[str, Any]] = []
+        public_member_total = 0
+        if isinstance(definition, ast.ClassDef):
+            bases = [ast.unparse(base) for base in definition.bases]
+            signature = f"class {definition.name}"
+            if bases:
+                signature += f"({', '.join(bases)})"
+            for member in definition.body:
+                if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)) and not (
+                    member.name.startswith("_")
+                ):
+                    public_member_total += 1
+                    if len(public_members) < MAX_PUBLIC_API_ITEMS:
+                        public_members.append(
+                            {
+                                "name": member.name,
+                                "signature": self._function_signature(member),
+                                "line": member.lineno,
+                                "docstring": ast.get_docstring(member, clean=True),
+                            }
+                        )
+        else:
+            signature = self._function_signature(definition)
+
+        return {
+            "symbol": source["symbol_name"],
+            "kind": source["symbol_kind"],
+            "signature": signature,
+            "location": f"{source['path']}:{source['definition_line']}",
+            "docstring": ast.get_docstring(definition, clean=True),
+            "bases": bases,
+            "decorators": decorators,
+            "public_api": {
+                "total": public_member_total,
+                "returned": len(public_members),
+                "truncated": public_member_total > len(public_members),
+                "items": public_members,
+            },
+            "related_tests": self._related_tests(source["symbol_name"]),
+        }
+
+    def _intent_relationships(self, intention, intent_id: str) -> dict[str, Any]:
+        canonical_id = str(UUID(intent_id))
+        nodes = {str(UUID(node.id)): node for node in intention.nodes.values()}
+        relationships = []
+        for edge in intention.edges:
+            source_id = str(UUID(edge.source))
+            target_id = str(UUID(edge.target))
+            if source_id == canonical_id:
+                direction = "outgoing"
+                other_id = target_id
+            elif target_id == canonical_id:
+                direction = "incoming"
+                other_id = source_id
+            else:
+                continue
+            other = nodes.get(other_id)
+            relationships.append(
+                {
+                    "direction": direction,
+                    "relationship": edge.type.value,
+                    "other": other.name if other else "unknown node",
+                    "description": edge.description,
+                }
+            )
+        relationships.sort(
+            key=lambda item: (
+                item["direction"],
+                item["relationship"],
+                item["other"].casefold(),
+                item["description"] or "",
+            )
+        )
+        return _bounded(relationships, MAX_INTENT_RELATIONSHIPS)
+
+    def _intent_summary(self, intention, intent_id: str) -> dict[str, Any]:
+        node = self._intent_node(intent_id, intention)
+        intent = node.intent
+        acceptance_criteria = []
+        provenance = []
+        assumptions = []
+        open_ambiguities = []
+        confidence: float | str = "not recorded"
+        approval_state = "not recorded"
+        if intent is not None:
+            acceptance_criteria = [
+                {
+                    "id": criterion.id,
+                    "statement": criterion.statement,
+                    "required_evidence": list(criterion.required_evidence),
+                    "mapping_review_status": "not_verified",
+                }
+                for criterion in intent.acceptance_criteria
+            ]
+            provenance = [item.model_dump(mode="json") for item in intent.provenance]
+            assumptions = list(intent.assumptions)
+            open_ambiguities = [
+                ambiguity.question
+                for ambiguity in intent.ambiguities
+                if ambiguity.status.value == "open"
+            ]
+            confidence = intent.confidence
+            approval_state = intent.approval.state.value
+        return {
+            "title": node.name,
+            "type": node.type.value,
+            "domain": node.domain,
+            "responsibility": _display_value(
+                node.description, "No responsibility statement recorded."
+            ),
+            "approval_state": approval_state,
+            "confidence": confidence,
+            "acceptance_criteria": _bounded(acceptance_criteria, MAX_INTENT_DETAILS),
+            "provenance": _bounded(provenance, MAX_INTENT_DETAILS),
+            "assumptions": _bounded(
+                [{"statement": item} for item in assumptions], MAX_INTENT_DETAILS
+            ),
+            "open_ambiguities": _bounded(
+                [{"question": item} for item in open_ambiguities],
+                MAX_INTENT_DETAILS,
+            ),
+            "relationships": self._intent_relationships(intention, node.id),
+        }
 
     def _candidate_summary(self, candidate, generator):
         locations = generator.source_locations.get(candidate["id"], [])
@@ -130,6 +575,85 @@ class MappingEngine:
         elif source_locations:
             summary["source_locations"] = source_locations
         return summary
+
+    def _decision_brief(
+        self,
+        intention,
+        record: dict[str, Any],
+        candidates: list[dict[str, Any]],
+        *,
+        supported: bool,
+    ) -> dict[str, Any]:
+        intent_summary = self._intent_summary(intention, record["intent"]["id"])
+        implementation = (
+            self._implementation_summary(candidates[0]["source"]) if supported else None
+        )
+        established = []
+        if record["classification"] == "candidate":
+            established.append(
+                "The Intention title and Reality symbol have the same normalized name "
+                "and compatible structural type."
+            )
+        else:
+            established.append(
+                f"Reconciliation classified this intent as {record['classification']}."
+            )
+        if implementation is not None:
+            established.append(
+                "Exactly one current Python definition resolves to the candidate source "
+                f"at {implementation['location']}."
+            )
+            if implementation["related_tests"]["total"]:
+                established.append(
+                    f"{implementation['related_tests']['total']} test function(s) contain "
+                    "an exact reference to the symbol."
+                )
+
+        not_established = [
+            "Whether the source symbol has the same responsibility as the Intention node.",
+            "Whether related tests exercise the acceptance criteria; references are not "
+            "behavioral proof.",
+        ]
+        not_established.extend(
+            "Acceptance criterion "
+            f"{index} is not behaviorally verified by this mapping review."
+            for index, _criterion in enumerate(
+                intent_summary["acceptance_criteria"]["items"], start=1
+            )
+        )
+        not_established.extend(
+            f"Open Intent ambiguity: {item['question']}"
+            for item in intent_summary["open_ambiguities"]["items"]
+        )
+        if intent_summary["acceptance_criteria"]["truncated"]:
+            not_established.append(
+                "Additional acceptance criteria were omitted from the bounded brief and "
+                "remain unverified."
+            )
+        if intent_summary["open_ambiguities"]["truncated"]:
+            not_established.append(
+                "Additional open ambiguities were omitted from the bounded brief."
+            )
+        return {
+            "decision_scope": "source_identity_linkage",
+            "default_decision": "defer",
+            "meaning": (
+                "Approval links one canonical Intent GUID to one exact source symbol. "
+                "It does not approve the Intent IR or prove acceptance criteria."
+            ),
+            "intention": intent_summary,
+            "implementation": implementation,
+            "assessment": {
+                "summary": (
+                    "Structural evidence narrows the candidate, but human judgment is "
+                    "required to decide responsibility equivalence."
+                ),
+                "structurally_unique": supported,
+                "behaviorally_verified": False,
+                "established": established,
+                "not_established": not_established,
+            },
+        }
 
     @staticmethod
     def _evidence_digest(payload: dict[str, Any]) -> str:
@@ -166,12 +690,19 @@ class MappingEngine:
             )
 
         supported = not blockers
+        decision_brief = self._decision_brief(
+            intention,
+            record,
+            candidates,
+            supported=supported,
+        )
         report: dict[str, Any] = {
-            "schema_version": MAPPING_SCHEMA_VERSION,
+            "schema_version": MAPPING_REVIEW_SCHEMA_VERSION,
             "classification": record["classification"],
             "intent": record["intent"],
             "candidates": candidates,
             "evidence": record["evidence"],
+            "decision_brief": decision_brief,
             "approval": {
                 "required": True,
                 "supported": supported,
@@ -182,11 +713,15 @@ class MappingEngine:
         if supported:
             report["evidence_digest"] = self._evidence_digest(
                 {
-                    "schema_version": MAPPING_SCHEMA_VERSION,
+                    "schema_version": MAPPING_REVIEW_SCHEMA_VERSION,
                     "classification": record["classification"],
                     "intent": record["intent"],
+                    "intent_semantics": self._intent_node(
+                        record["intent"]["id"], intention
+                    ).model_dump(mode="json"),
                     "candidate": candidates[0],
                     "evidence": record["evidence"],
+                    "decision_brief": decision_brief,
                 }
             )
         return report
@@ -332,7 +867,7 @@ class MappingEngine:
             self._reject_existing_marker(canonical_intent_id)
 
             receipt = {
-                "schema_version": MAPPING_SCHEMA_VERSION,
+                "schema_version": MAPPING_APPROVAL_SCHEMA_VERSION,
                 "intent_id": canonical_intent_id,
                 "candidate_reality_id": str(UUID(current_reality_id)),
                 "source_path": source["path"],
@@ -358,7 +893,7 @@ class MappingEngine:
                 raise
 
             return {
-                "schema_version": MAPPING_SCHEMA_VERSION,
+                "schema_version": MAPPING_APPROVAL_SCHEMA_VERSION,
                 "receipt": receipt,
                 "postcondition": postcondition,
             }

--- a/src/aio_agentic_sdlc/mcp_server.py
+++ b/src/aio_agentic_sdlc/mcp_server.py
@@ -390,7 +390,7 @@ def review_mapping(
         str, Field(description="Absolute path to the project directory")
     ] = ".",
 ) -> str:
-    """Return fresh source-bound evidence for one mapping decision."""
+    """Return a human-first decision brief plus fresh source-bound audit evidence."""
 
     try:
         intention_path = os.path.join(os.path.abspath(project_path), INTENTION_DAG_FILE)

--- a/tests/test_dag_cli.py
+++ b/tests/test_dag_cli.py
@@ -333,6 +333,8 @@ def test_cli_mapping_review_and_approve_use_the_same_fresh_evidence(tmp_path):
             str(tmp_path),
             "--intent-id",
             intent_id,
+            "--format",
+            "json",
         ],
     )
 
@@ -366,6 +368,47 @@ def test_cli_mapping_review_and_approve_use_the_same_fresh_evidence(tmp_path):
     approval = json.loads(approve_result.output)
     assert approval["postcondition"]["classification"] == "confirmed"
     assert f"# aio-sdlc-node: {intent_id}" in source_path.read_text(encoding="utf-8")
+
+
+def test_cli_mapping_review_defaults_to_a_human_decision_brief(tmp_path):
+    intent_id = "6506870b-b262-4f54-b6e9-43de4a873a55"
+    source_path = tmp_path / "src" / "archiver.py"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text(
+        'class PRDArchiver:\n    """Archive accepted PRDs."""\n',
+        encoding="utf-8",
+    )
+    (tmp_path / INTENTION_DAG_FILE).parent.mkdir(parents=True)
+    DAGManager(
+        Metadata(name="Mapping CLI", version="1.0"),
+        [
+            Node(
+                id=intent_id,
+                type=NodeType.COMPONENT,
+                name="PRD Archiver",
+                description="Archive accepted PRDs without losing provenance.",
+            )
+        ],
+        [],
+    ).save(str(tmp_path / INTENTION_DAG_FILE))
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "mapping",
+            "review",
+            "--project-path",
+            str(tmp_path),
+            "--intent-id",
+            intent_id,
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Mapping decision: PRD Archiver -> PRDArchiver" in result.output
+    assert "What is intended" in result.output
+    assert "Default: DEFER" in result.output
+    assert "Audit metadata" in result.output
 
 
 def test_cli_diff_is_safe_by_default_and_legacy_is_explicit(sample_dag_file, tmp_path):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import re
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
@@ -9,14 +10,69 @@ import pytest
 
 from aio_agentic_sdlc.dag_manager import DAGManager
 from aio_agentic_sdlc.dag_models import Metadata, Node, NodeType
-from aio_agentic_sdlc.mapping import MappingApproval, MappingEngine, MappingError
+from aio_agentic_sdlc.intent_ir import IntentIR
+from aio_agentic_sdlc.mapping import (
+    MappingApproval,
+    MappingEngine,
+    MappingError,
+    render_mapping_review,
+)
 from aio_agentic_sdlc.reality_dag_generator import RealityDAGGenerator
 from aio_agentic_sdlc.workspace import INTENTION_DAG_FILE, workspace_migration_lock
 
 INTENT_ID = "6506870b-b262-4f54-b6e9-43de4a873a55"
 
 
-def _project(tmp_path: Path, sources: dict[str, bytes | str], *, name="PRD Archiver"):
+def _intent_ir(statement: str = "Archive accepted PRDs without losing provenance."):
+    return IntentIR.model_validate(
+        {
+            "schema_version": 1,
+            "provenance": [
+                {
+                    "source_type": "human_statement",
+                    "reference": "conversation:test",
+                    "statement": statement,
+                }
+            ],
+            "assumptions": ["Accepted PRDs have stable source paths."],
+            "ambiguities": [
+                {
+                    "question": "Should rejected PRDs be retained?",
+                    "status": "open",
+                }
+            ],
+            "confidence": 0.8,
+            "acceptance_criteria": [
+                {
+                    "id": "AC-1",
+                    "statement": statement,
+                    "required_evidence": ["test:archive_preserves_provenance"],
+                }
+            ],
+            "revision_history": [
+                {
+                    "revision": 1,
+                    "recorded_at": "2026-08-13T10:00:00-04:00",
+                    "actor": "Felix",
+                    "generator_version": "test/v1",
+                    "summary": "Captured the intended archiving responsibility.",
+                }
+            ],
+            "responsible_agent": "sdlc_cartographer",
+            "generator_version": "test/v1",
+            "approval": {"state": "review_required"},
+        }
+    )
+
+
+def _project(
+    tmp_path: Path,
+    sources: dict[str, bytes | str],
+    *,
+    name="PRD Archiver",
+    description=None,
+    intent=None,
+):
     for relative_path, content in sources.items():
         target = tmp_path / relative_path
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -27,7 +83,15 @@ def _project(tmp_path: Path, sources: dict[str, bytes | str], *, name="PRD Archi
 
     intention = DAGManager(
         Metadata(name="Mapping Test", version="1.0"),
-        [Node(id=INTENT_ID, type=NodeType.COMPONENT, name=name)],
+        [
+            Node(
+                id=INTENT_ID,
+                type=NodeType.COMPONENT,
+                name=name,
+                description=description,
+                intent=intent,
+            )
+        ],
         [],
     )
     intention_path = tmp_path / INTENTION_DAG_FILE
@@ -56,7 +120,7 @@ def test_mapping_review_binds_fresh_candidate_to_exact_source_without_mutation(
 
     review = engine.review(INTENT_ID)
 
-    assert review["schema_version"] == 1
+    assert review["schema_version"] == 2
     assert review["classification"] == "candidate"
     assert review["intent"]["id"] == INTENT_ID
     assert len(review["candidates"]) == 1
@@ -80,6 +144,127 @@ def test_mapping_review_binds_fresh_candidate_to_exact_source_without_mutation(
     assert intention_path.read_bytes() == before_intention
     assert not (tmp_path / "reality-dag.yaml").exists()
     assert not (tmp_path / "backlog.json").exists()
+
+
+def test_mapping_review_is_a_human_decision_brief_not_an_id_table(tmp_path):
+    source = (
+        "class PRDArchiver(BaseArchiver):\n"
+        '    """Archive accepted PRDs and preserve their source provenance."""\n\n'
+        "    def archive(self, source_path: str) -> str:\n"
+        '        """Return the archived path."""\n'
+        "        return source_path\n\n"
+        "    def _internal(self):\n"
+        "        return None\n"
+    )
+    engine, _ = _project(
+        tmp_path,
+        {
+            "src/archiver.py": source,
+            "tests/test_archiver.py": (
+                "from src.archiver import PRDArchiver\n\n"
+                "def test_archive_preserves_provenance():\n"
+                "    assert PRDArchiver().archive('accepted.md') == 'accepted.md'\n"
+            ),
+        },
+        description="Archive accepted PRDs without losing provenance.",
+        intent=_intent_ir(),
+    )
+
+    review = engine.review(INTENT_ID)
+    brief = review["decision_brief"]
+
+    assert brief["default_decision"] == "defer"
+    assert brief["decision_scope"] == "source_identity_linkage"
+    assert brief["intention"]["responsibility"] == (
+        "Archive accepted PRDs without losing provenance."
+    )
+    assert brief["intention"]["acceptance_criteria"]["items"] == [
+        {
+            "id": "AC-1",
+            "statement": "Archive accepted PRDs without losing provenance.",
+            "required_evidence": ["test:archive_preserves_provenance"],
+            "mapping_review_status": "not_verified",
+        }
+    ]
+    implementation = brief["implementation"]
+    assert implementation["location"] == "src/archiver.py:1"
+    assert implementation["docstring"] == (
+        "Archive accepted PRDs and preserve their source provenance."
+    )
+    assert implementation["bases"] == ["BaseArchiver"]
+    assert [item["name"] for item in implementation["public_api"]["items"]] == [
+        "archive"
+    ]
+    assert implementation["related_tests"]["items"][0]["test"] == (
+        "test_archive_preserves_provenance"
+    )
+    assert brief["assessment"]["behaviorally_verified"] is False
+    assert "human judgment" in brief["assessment"]["summary"].lower()
+
+    rendered = render_mapping_review(review)
+    assert "What is intended" in rendered
+    assert "Archive accepted PRDs without losing provenance." in rendered
+    assert "PRDArchiver" in rendered
+    assert "archive(self, source_path: str)" in rendered
+    assert "Related tests (references, not proof)" in rendered
+    assert "Default: DEFER" in rendered
+    assert rendered.index("Audit metadata") > rendered.index("Decision choices")
+    decision_text = rendered.split("Audit metadata", maxsplit=1)[0]
+    assert (
+        re.search(
+            r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+            r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+            decision_text,
+        )
+        is None
+    )
+
+
+def test_mapping_digest_binds_the_reviewed_intent_semantics(tmp_path):
+    source = "class PRDArchiver:\n    pass\n"
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first, _ = _project(
+        first_root,
+        {"src/archiver.py": source},
+        description="Archive accepted PRDs.",
+        intent=_intent_ir("Archive accepted PRDs."),
+    )
+    second, _ = _project(
+        second_root,
+        {"src/archiver.py": source},
+        description="Archive accepted PRDs and preserve provenance.",
+        intent=_intent_ir("Archive accepted PRDs and preserve provenance."),
+    )
+
+    assert (
+        first.review(INTENT_ID)["evidence_digest"]
+        != second.review(INTENT_ID)["evidence_digest"]
+    )
+
+
+def test_mapping_review_bounds_related_test_evidence(tmp_path):
+    tests = "from src.archiver import PRDArchiver\n\n" + "\n\n".join(
+        f"def test_case_{index}():\n    assert PRDArchiver() is not None"
+        for index in range(12)
+    )
+    engine, _ = _project(
+        tmp_path,
+        {
+            "src/archiver.py": "class PRDArchiver:\n    pass\n",
+            "tests/test_archiver.py": tests,
+        },
+        description="Archive accepted PRDs.",
+        intent=_intent_ir("Archive accepted PRDs."),
+    )
+
+    related = engine.review(INTENT_ID)["decision_brief"]["implementation"][
+        "related_tests"
+    ]
+
+    assert related["total"] == 12
+    assert related["returned"] == 10
+    assert related["truncated"] is True
 
 
 def test_mapping_approval_atomically_marks_and_confirms_exact_python_symbol(tmp_path):


### PR DESCRIPTION
## Summary
- replace GUID-first mapping review output with a human decision brief
- compare intended responsibility, criteria, provenance, assumptions, and relationships against the exact Python symbol, documentation, public API, and related tests
- keep UUIDs and the evidence digest in a final audit-only section; JSON remains available with --format json
- bind approvals to the complete reviewed Intent IR and source evidence
- document the identity-only meaning of mapping approval and default unresolved decisions to defer

## Dogfood evidence
- all five current structural candidates render without UUIDs in the human decision portion
- canonical reconciliation remains non-destructive: 59 Intention, 588 Reality, 3 confirmed, 5 candidates, 0 ambiguous, 51 unmapped
- no source identity mapping was promoted; those remain explicit human decisions
- Reality SHA-256: 94498FD9818B3F652B19DF1207F518E374615B6885D06C7D515C74C1D0A8D19A
- reconciliation SHA-256: 9257DE6F9ECC7A6F5F74F80E0D4953D16CE87349DB66BC3455016039CC379ACA

## Validation
- uv sync --frozen --group dev
- uv lock --check
- uv build
- uv run --no-sync pytest -W error -q (274 passed)
- Ruff and Black on changed Python files
- Markdownlint on changed documentation and local recovery roadmap
- manage-sdlc skill validator
- Codex plugin validator
- strict DAG and complete Intent IR validation
- Reality and reconciliation regenerated byte-for-byte after build