### PR TITLE
feat(mapping): promote approved source identities

### DIFF
--- a/.aio-agentic-sdlc/changes/approved-source-mappings/reconciliation.json
+++ b/.aio-agentic-sdlc/changes/approved-source-mappings/reconciliation.json
@@ -1,0 +1,330 @@
+{
+  "schema_version": 1,
+  "summary": {
+    "intention_nodes": 59,
+    "reality_nodes": 588,
+    "confirmed": 8,
+    "candidate": 0,
+    "ambiguous": 0,
+    "unmapped": 51,
+    "unclassified_reality": 580
+  },
+  "limit": {
+    "max_items": 15,
+    "total_items": 639,
+    "returned_items": 15,
+    "truncated": true
+  },
+  "items": [
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b",
+        "type": "component",
+        "name": "Reality DAG Generator"
+      },
+      "reality_candidates": [
+        {
+          "id": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b",
+          "type": "component",
+          "name": "RealityDAGGenerator"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "6317643a-a8fc-5026-b373-9330004bc90d",
+        "type": "component",
+        "name": "Approval-Gated Source Mapping"
+      },
+      "reality_candidates": [
+        {
+          "id": "6317643a-a8fc-5026-b373-9330004bc90d",
+          "type": "component",
+          "name": "MappingEngine"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "6317643a-a8fc-5026-b373-9330004bc90d"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "6506870b-b262-4f54-b6e9-43de4a873a55",
+        "type": "component",
+        "name": "PRD Archiver"
+      },
+      "reality_candidates": [
+        {
+          "id": "6506870b-b262-4f54-b6e9-43de4a873a55",
+          "type": "component",
+          "name": "PRDArchiver"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "6506870b-b262-4f54-b6e9-43de4a873a55"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "685b1d12-3eed-48f6-9fa8-b8ec88a5587f",
+        "type": "component",
+        "name": "Traceability Validator"
+      },
+      "reality_candidates": [
+        {
+          "id": "685b1d12-3eed-48f6-9fa8-b8ec88a5587f",
+          "type": "component",
+          "name": "TraceabilityValidator"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "685b1d12-3eed-48f6-9fa8-b8ec88a5587f"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+        "type": "component",
+        "name": "Evidence-Gated Reconciliation Baseline"
+      },
+      "reality_candidates": [
+        {
+          "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+          "type": "module",
+          "name": "reconciliation.py"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "9015c8a3-fd14-5598-916d-d03fcf41e415"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "9865715b-99a5-4dcb-ba92-90b03cc3cf1c",
+        "type": "component",
+        "name": "Tree-Sitter Parser"
+      },
+      "reality_candidates": [
+        {
+          "id": "9865715b-99a5-4dcb-ba92-90b03cc3cf1c",
+          "type": "component",
+          "name": "TreeSitterParser"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "9865715b-99a5-4dcb-ba92-90b03cc3cf1c"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "d0307d83-371e-4bb6-925d-84a4b70beb6b",
+        "type": "component",
+        "name": "Parser Factory"
+      },
+      "reality_candidates": [
+        {
+          "id": "d0307d83-371e-4bb6-925d-84a4b70beb6b",
+          "type": "component",
+          "name": "ParserFactory"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "d0307d83-371e-4bb6-925d-84a4b70beb6b"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "confirmed",
+      "intent": {
+        "id": "fa35fa8a-b6b5-40ca-9080-b31421117e37",
+        "type": "component",
+        "name": "Diffing Engine"
+      },
+      "reality_candidates": [
+        {
+          "id": "fa35fa8a-b6b5-40ca-9080-b31421117e37",
+          "type": "component",
+          "name": "DiffingEngine"
+        }
+      ],
+      "evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "fa35fa8a-b6b5-40ca-9080-b31421117e37"
+        }
+      ],
+      "requires_approval": false
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "07e7e16c-c4d7-4f59-ac98-5d33599f0270",
+        "type": "agent",
+        "name": "SDLC Architect Agent"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "09497db1-e4c8-43f3-8c27-ee8577b2b59f",
+        "type": "component",
+        "name": "TUI Dashboard"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "10d4c0ba-de03-49ac-ae0e-41048fd557ed",
+        "type": "component",
+        "name": "Daemon Watcher"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "1525a991-0ffa-4f82-b5a1-b23602346ca4",
+        "type": "endpoint",
+        "name": "Health Check Endpoint"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "15302505-8828-525a-bebb-f72621f467a1",
+        "type": "component",
+        "name": "Cross-language Ontology Portability"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "22822d50-4438-4b48-821f-451933f557dd",
+        "type": "agent",
+        "name": "SDLC Intake Agent"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    },
+    {
+      "subject_kind": "intent",
+      "classification": "unmapped",
+      "intent": {
+        "id": "2499ec97-aa53-4f54-8a55-5406403a647b",
+        "type": "component",
+        "name": "DAG Schema Migrator"
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 20,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "evidence": [],
+      "requires_approval": true
+    }
+  ]
+}

--- a/.aio-agentic-sdlc/reality-dag.yaml
+++ b/.aio-agentic-sdlc/reality-dag.yaml
@@ -226,15 +226,15 @@ nodes:
   type: component
   name: remove_item
   description: Function remove_item
-- id: 4332ee05-cded-51dc-b884-7249af9d97cd
+- id: 685b1d12-3eed-48f6-9fa8-b8ec88a5587f
   type: component
   name: TraceabilityValidator
   description: Class TraceabilityValidator
-- id: 6bf977ee-c94d-5750-acca-d8c0b707edf0
+- id: 5a7a7605-59ec-53a2-950b-6fa1a6262bdb
   type: component
   name: __init__
   description: Function __init__
-- id: d53a9141-bdd1-55ab-8340-1dddaac885ec
+- id: 08ffd22c-95b2-59da-b865-f91919682f56
   type: component
   name: validate
   description: Function validate
@@ -490,17 +490,17 @@ nodes:
   type: component
   name: legacy_structural
   description: Function legacy_structural
-- id: 6199cd62-9332-5ad1-b458-18bd2e865da1
+- id: fa35fa8a-b6b5-40ca-9080-b31421117e37
   type: component
   name: DiffingEngine
   description: "\r\n    Computes the difference between an Intention DAG and a Reality\
     \ DAG,\r\n    generating a backlog of tasks required to reconcile Reality with\
     \ Intention.\r\n    "
-- id: 0c16f2bc-7c68-5ad9-bd22-b4223d083f1e
+- id: 502fdf74-dcf2-53ca-b801-b2cb869c5a7d
   type: component
   name: __init__
   description: Function __init__
-- id: d183433d-01cb-57e1-b566-02da520084e6
+- id: 49ec4886-cacf-50a5-ba6b-061df8eb6cf6
   type: component
   name: calculate_diff
   description: Calculate a bounded safe plan unless legacy behavior is explicit.
@@ -769,16 +769,16 @@ nodes:
   type: module
   name: reality_dag_generator.py
   description: Module src.aio_agentic_sdlc.reality_dag_generator
-- id: 5f9d3dc7-cd7e-5402-86cd-356a4b6846fb
+- id: 0fea8fea-9a23-404b-a16b-a9c9c3990e1b
   type: component
   name: RealityDAGGenerator
   description: "\r\n    Generates a Reality DAG by statically analyzing source code.\r\
     \n    Implements a tree-sitter parser to be stack-agnostic.\r\n    "
-- id: d484d25c-d3d6-5215-93bb-76543a0e7867
+- id: 4662e823-2b21-5db2-9196-4300236f9f5b
   type: component
   name: __init__
   description: Function __init__
-- id: 2f305d49-796d-553c-b67c-daf04ff09189
+- id: 43ee63d6-5d85-5c61-b96a-427f3a33ef1e
   type: component
   name: generate
   description: Function generate
@@ -984,15 +984,15 @@ nodes:
   type: module
   name: factory.py
   description: Module src.aio_agentic_sdlc.parsers.factory
-- id: a7278b66-0ac6-5e6b-91d7-0604d42cc40f
+- id: d0307d83-371e-4bb6-925d-84a4b70beb6b
   type: component
   name: ParserFactory
   description: Class ParserFactory
-- id: f7ec265d-59e9-5d8d-bd47-5c91bc4cd357
+- id: ad263b92-52de-552d-a9a0-befb5824af65
   type: component
   name: __init__
   description: Function __init__
-- id: 17e3ea75-f350-5468-9ebd-98f215f4a196
+- id: c61fa53d-46a9-51d5-901f-ac840eb46369
   type: component
   name: get_parser
   description: Function get_parser
@@ -1012,15 +1012,15 @@ nodes:
   type: module
   name: python_parser.py
   description: Module src.aio_agentic_sdlc.parsers.python_parser
-- id: 68d91d09-7a15-5e5c-8387-68ac2ec30139
+- id: 9865715b-99a5-4dcb-ba92-90b03cc3cf1c
   type: component
   name: TreeSitterParser
   description: Class TreeSitterParser
-- id: a7b81d98-2450-55f8-98f8-6f92d6136a23
+- id: 92d83e86-d4e3-56da-9fc2-9f4513baa910
   type: component
   name: __init__
   description: Function __init__
-- id: 01382c12-efbb-5d74-8ce4-04ee5ace65a5
+- id: 297c9311-ffe7-5ff3-b4f7-9e6ecea0aaa2
   type: component
   name: parse
   description: Function parse
@@ -2560,13 +2560,13 @@ edges:
   target: 08949c1f-e697-5962-9aaf-919f16b1d857
   type: contains
 - source: dda24752-8c90-5617-8ee2-4727bb22232f
-  target: 4332ee05-cded-51dc-b884-7249af9d97cd
+  target: 685b1d12-3eed-48f6-9fa8-b8ec88a5587f
   type: contains
-- source: 4332ee05-cded-51dc-b884-7249af9d97cd
-  target: 6bf977ee-c94d-5750-acca-d8c0b707edf0
+- source: 685b1d12-3eed-48f6-9fa8-b8ec88a5587f
+  target: 5a7a7605-59ec-53a2-950b-6fa1a6262bdb
   type: contains
-- source: 4332ee05-cded-51dc-b884-7249af9d97cd
-  target: d53a9141-bdd1-55ab-8340-1dddaac885ec
+- source: 685b1d12-3eed-48f6-9fa8-b8ec88a5587f
+  target: 08ffd22c-95b2-59da-b865-f91919682f56
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: 51038e11-df2c-549d-b731-bd99dd919ed5
@@ -2755,13 +2755,13 @@ edges:
   target: d4666098-add5-5c06-a75b-56d4561d8fec
   type: contains
 - source: 193b8ecb-ff6a-5c43-aa4d-ed19e677d282
-  target: 6199cd62-9332-5ad1-b458-18bd2e865da1
+  target: fa35fa8a-b6b5-40ca-9080-b31421117e37
   type: contains
-- source: 6199cd62-9332-5ad1-b458-18bd2e865da1
-  target: 0c16f2bc-7c68-5ad9-bd22-b4223d083f1e
+- source: fa35fa8a-b6b5-40ca-9080-b31421117e37
+  target: 502fdf74-dcf2-53ca-b801-b2cb869c5a7d
   type: contains
-- source: 6199cd62-9332-5ad1-b458-18bd2e865da1
-  target: d183433d-01cb-57e1-b566-02da520084e6
+- source: fa35fa8a-b6b5-40ca-9080-b31421117e37
+  target: 49ec4886-cacf-50a5-ba6b-061df8eb6cf6
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: 03ab3d9a-beb1-5a32-b3f4-5efdddeee956
@@ -2953,13 +2953,13 @@ edges:
   target: 1dbef474-b42c-50ba-81a6-fcf97002ad6c
   type: contains
 - source: 1dbef474-b42c-50ba-81a6-fcf97002ad6c
-  target: 5f9d3dc7-cd7e-5402-86cd-356a4b6846fb
+  target: 0fea8fea-9a23-404b-a16b-a9c9c3990e1b
   type: contains
-- source: 5f9d3dc7-cd7e-5402-86cd-356a4b6846fb
-  target: d484d25c-d3d6-5215-93bb-76543a0e7867
+- source: 0fea8fea-9a23-404b-a16b-a9c9c3990e1b
+  target: 4662e823-2b21-5db2-9196-4300236f9f5b
   type: contains
-- source: 5f9d3dc7-cd7e-5402-86cd-356a4b6846fb
-  target: 2f305d49-796d-553c-b67c-daf04ff09189
+- source: 0fea8fea-9a23-404b-a16b-a9c9c3990e1b
+  target: 43ee63d6-5d85-5c61-b96a-427f3a33ef1e
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: 9015c8a3-fd14-5598-916d-d03fcf41e415
@@ -3106,13 +3106,13 @@ edges:
   target: e9b84b03-d3bc-543e-a3c2-161f583768a4
   type: contains
 - source: e9b84b03-d3bc-543e-a3c2-161f583768a4
-  target: a7278b66-0ac6-5e6b-91d7-0604d42cc40f
+  target: d0307d83-371e-4bb6-925d-84a4b70beb6b
   type: contains
-- source: a7278b66-0ac6-5e6b-91d7-0604d42cc40f
-  target: f7ec265d-59e9-5d8d-bd47-5c91bc4cd357
+- source: d0307d83-371e-4bb6-925d-84a4b70beb6b
+  target: ad263b92-52de-552d-a9a0-befb5824af65
   type: contains
-- source: a7278b66-0ac6-5e6b-91d7-0604d42cc40f
-  target: 17e3ea75-f350-5468-9ebd-98f215f4a196
+- source: d0307d83-371e-4bb6-925d-84a4b70beb6b
+  target: c61fa53d-46a9-51d5-901f-ac840eb46369
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: e3b72ae9-9e2d-5a12-9614-34f892a0e932
@@ -3127,13 +3127,13 @@ edges:
   target: 4271a927-f51e-512e-b272-45fa54fbb3d3
   type: contains
 - source: 4271a927-f51e-512e-b272-45fa54fbb3d3
-  target: 68d91d09-7a15-5e5c-8387-68ac2ec30139
+  target: 9865715b-99a5-4dcb-ba92-90b03cc3cf1c
   type: contains
-- source: 68d91d09-7a15-5e5c-8387-68ac2ec30139
-  target: a7b81d98-2450-55f8-98f8-6f92d6136a23
+- source: 9865715b-99a5-4dcb-ba92-90b03cc3cf1c
+  target: 92d83e86-d4e3-56da-9fc2-9f4513baa910
   type: contains
-- source: 68d91d09-7a15-5e5c-8387-68ac2ec30139
-  target: 01382c12-efbb-5d74-8ce4-04ee5ace65a5
+- source: 9865715b-99a5-4dcb-ba92-90b03cc3cf1c
+  target: 297c9311-ffe7-5ff3-b4f7-9e6ecea0aaa2
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: 77759c7c-420b-572a-a765-65c3d3479dd5

--- a/src/aio_agentic_sdlc/core.py
+++ b/src/aio_agentic_sdlc/core.py
@@ -459,6 +459,8 @@ def remove_item(name, project_path="."):
     save_backlog(data, project_path, operation="backlog.remove")
 
 
+# aio-sdlc-mapping-approval: {"approved_at":"2026-08-13T19:29:14.286017-04:00","approved_by":"Felix","candidate_reality_id":"4332ee05-cded-51dc-b884-7249af9d97cd","evidence_digest":"785fb78003c07acecef12413f387caffdf6eb17b2676b55ee734a51006195c08","intent_id":"685b1d12-3eed-48f6-9fa8-b8ec88a5587f","rationale":"Approved the TraceabilityValidator source identity; responsibility and validate API match, without claiming behavioral verification.","schema_version":1,"source_path":"src/aio_agentic_sdlc/core.py","source_sha256":"89b340f7032a84e0c9e7f032814ee15441ed06d4e4409e8d3d790ed6585faa2d","symbol_kind":"class","symbol_name":"TraceabilityValidator"}
+# aio-sdlc-node: 685b1d12-3eed-48f6-9fa8-b8ec88a5587f
 class TraceabilityValidator:
     def __init__(
         self,

--- a/src/aio_agentic_sdlc/diffing_engine.py
+++ b/src/aio_agentic_sdlc/diffing_engine.py
@@ -45,6 +45,8 @@ class DiffPolicy:
         return cls(mode="legacy_structural")
 
 
+# aio-sdlc-mapping-approval: {"approved_at":"2026-08-13T19:29:14.286017-04:00","approved_by":"Felix","candidate_reality_id":"6199cd62-9332-5ad1-b458-18bd2e865da1","evidence_digest":"49c7ce1f1cf9501958cbb0a20b0919911d5d9270f20b46b52b7a35535a7eaaf8","intent_id":"fa35fa8a-b6b5-40ca-9080-b31421117e37","rationale":"Approved the DiffingEngine source identity; DAG diff responsibility, documentation, public API, and related-test references match.","schema_version":1,"source_path":"src/aio_agentic_sdlc/diffing_engine.py","source_sha256":"813cc0a840b1c380e98ab6b1fa0b64a060bfc3bba05682b2165cf954f54cee94","symbol_kind":"class","symbol_name":"DiffingEngine"}
+# aio-sdlc-node: fa35fa8a-b6b5-40ca-9080-b31421117e37
 class DiffingEngine:
     """
     Computes the difference between an Intention DAG and a Reality DAG,

--- a/src/aio_agentic_sdlc/parsers/factory.py
+++ b/src/aio_agentic_sdlc/parsers/factory.py
@@ -4,6 +4,8 @@ from .python_parser import PYTHON_LANGUAGE, TreeSitterParser
 from .visitors import TreeSitterVisitor
 
 
+# aio-sdlc-mapping-approval: {"approved_at":"2026-08-13T19:29:14.286017-04:00","approved_by":"Felix","candidate_reality_id":"a7278b66-0ac6-5e6b-91d7-0604d42cc40f","evidence_digest":"1c322789fdfb8510307391326e0f9c8b16eb36833922846aaaf460b2c857b854","intent_id":"d0307d83-371e-4bb6-925d-84a4b70beb6b","rationale":"Approved the ParserFactory source identity; extension-based parser selection responsibility and public API match.","schema_version":1,"source_path":"src/aio_agentic_sdlc/parsers/factory.py","source_sha256":"532714443f9a88c178c6e666de53447ca1c017f0525941802b4bdbe2ef088b03","symbol_kind":"class","symbol_name":"ParserFactory"}
+# aio-sdlc-node: d0307d83-371e-4bb6-925d-84a4b70beb6b
 class ParserFactory:
     def __init__(self):
         self.parsers = {

--- a/src/aio_agentic_sdlc/parsers/python_parser.py
+++ b/src/aio_agentic_sdlc/parsers/python_parser.py
@@ -20,6 +20,8 @@ DEFINITION_TYPES = {
 }
 
 
+# aio-sdlc-mapping-approval: {"approved_at":"2026-08-13T19:29:14.286017-04:00","approved_by":"Felix","candidate_reality_id":"68d91d09-7a15-5e5c-8387-68ac2ec30139","evidence_digest":"a554f11c71a8625f074e1b0540fcd58bb7f1957fcde73b934e5103f21c90110a","intent_id":"9865715b-99a5-4dcb-ba92-90b03cc3cf1c","rationale":"Approved the TreeSitterParser source identity; parser responsibility, base type, and parse API match, without claiming behavioral verification.","schema_version":1,"source_path":"src/aio_agentic_sdlc/parsers/python_parser.py","source_sha256":"2b27f2d7d3f2908282a87bd7144a2a4160fdbf1fbf6a956c03815266a5eee949","symbol_kind":"class","symbol_name":"TreeSitterParser"}
+# aio-sdlc-node: 9865715b-99a5-4dcb-ba92-90b03cc3cf1c
 class TreeSitterParser(BaseFileParser):
     def __init__(self, language: Language, visitor_class: type):
         self.parser = Parser(language)

--- a/src/aio_agentic_sdlc/reality_dag_generator.py
+++ b/src/aio_agentic_sdlc/reality_dag_generator.py
@@ -30,6 +30,8 @@ def _is_ignored_directory(directory: str) -> bool:
     return normalized in IGNORED_DIRECTORIES or normalized.endswith(".egg-info")
 
 
+# aio-sdlc-mapping-approval: {"approved_at":"2026-08-13T19:29:14.286017-04:00","approved_by":"Felix","candidate_reality_id":"5f9d3dc7-cd7e-5402-86cd-356a4b6846fb","evidence_digest":"506a82e619bca8370b7af081f885edaa08bea033761e11a5b30924066e73b9f5","intent_id":"0fea8fea-9a23-404b-a16b-a9c9c3990e1b","rationale":"Approved the RealityDAGGenerator source identity; responsibility and public API match the reviewed Intention node.","schema_version":1,"source_path":"src/aio_agentic_sdlc/reality_dag_generator.py","source_sha256":"c688f5fe800d8178dae6bb861f71b8ac59e6015165e346bdecb647966371e242","symbol_kind":"class","symbol_name":"RealityDAGGenerator"}
+# aio-sdlc-node: 0fea8fea-9a23-404b-a16b-a9c9c3990e1b
 class RealityDAGGenerator:
     """
     Generates a Reality DAG by statically analyzing source code.


### PR DESCRIPTION
## Summary
- record Felix's approval of five human-reviewed Intention-to-source mappings
- promote the corresponding source symbols to canonical Intention GUIDs
- regenerate the canonical Reality DAG and store bounded reconciliation evidence

## Outcome
- confirmed mappings: 3 -> 8
- structural candidates: 5 -> 0
- unmapped intentions: 51
- unclassified Reality nodes: 580

This promotion establishes source identity only. It does not claim behavioral verification or completion of the remaining intentions. The next roadmap step is evidence-based drift triage for the 51 unmapped intentions and four proposed confirmed-node relationships.

## Validation
- `uv run --no-sync pytest -W error -q` (274 passed)
- `uv lock --check`
- `uv build`
- Ruff and Black on changed Python sources
- strict Intention and Reality DAG validation, including complete Intent IR coverage
- canonical Reality regeneration reproduced byte-for-byte (`75E60D4DE4C0E038B82C5779A142B69EDB405DEA0CEDFC8E49C9E3CBB88824CF`)
- reconciliation report reproduced byte-for-byte (`58043BDCDFFD15882D9668B505061A9E894CEFEFDCEB6C8DB2F94C3770CBE8E0`)