### PR TITLE
feat(reconciliation): add approval-aware drift triage

### DIFF
--- a/.aio-agentic-sdlc/changes/drift-triage/decisions.json
+++ b/.aio-agentic-sdlc/changes/drift-triage/decisions.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "plan_digest": "c8bc15b752513042dd3b8120da48eaeef817315aa787cb1ec394f32d479267ae",
+  "decisions": [
+    {
+      "subject_key": "intent:841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "classification": "missing_implementation",
+      "rationale": "The approved visualization acceptance criteria require CLI and MCP visualization surfaces, comparison evidence, and documented review workflow; none exists in the current source or public tool surface.",
+      "evidence": [
+        "intent:DAG-VIS-AC1-through-DAG-VIS-AC4",
+        "inspection:dag-tool-has-no-visualize-command",
+        "inspection:mcp-server-has-no-visualize-dag-tool"
+      ],
+      "decided_by": "sdlc_cartographer",
+      "decided_at": "2026-08-15T15:53:51.4813516-04:00"
+    },
+    {
+      "subject_key": "intent:f4658dd7-1ea1-5e1f-b851-2a376cc1649a",
+      "classification": "framework_tooling_drift",
+      "rationale": "Legacy Intent IR migration is implemented and verified as LegacyIntentMigrator, but deterministic reconciliation cannot map the differently named source symbol without an approved source-identity workflow for unmapped intent.",
+      "evidence": [
+        "source:src/aio_agentic_sdlc/intent_migration.py#LegacyIntentMigrator",
+        "tests:tests/test_intent_migration.py",
+        "artifact:.aio-agentic-sdlc/changes/legacy-intent-ir-migration/result.json"
+      ],
+      "decided_by": "sdlc_cartographer",
+      "decided_at": "2026-08-15T15:53:51.4813516-04:00"
+    }
+  ]
+}

--- a/.aio-agentic-sdlc/changes/drift-triage/decisions.json
+++ b/.aio-agentic-sdlc/changes/drift-triage/decisions.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "plan_digest": "c8bc15b752513042dd3b8120da48eaeef817315aa787cb1ec394f32d479267ae",
+  "plan_digest": "fa871c95a9a1997c9a466cf4035dcb78100f1d46d1874eb6d2fc1519541da062",
   "decisions": [
     {
       "subject_key": "intent:841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",

--- a/.aio-agentic-sdlc/changes/drift-triage/report.json
+++ b/.aio-agentic-sdlc/changes/drift-triage/report.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "source": {
     "intention_sha256": "e523f24914615974ab0cd99c3c33a97d63c68fb2a326989a3c3f00560d89f239",
-    "reality_sha256": "23d7307f201f3c49c8d26099c954f42f5ae1efbf9a65aa00a206dae23486594a",
-    "plan_digest": "c8bc15b752513042dd3b8120da48eaeef817315aa787cb1ec394f32d479267ae"
+    "reality_sha256": "ef06792875c448f7d2d3a411d37cf56484ab0c9e84a4d1e975b5e364f1eb9fb4",
+    "plan_digest": "fa871c95a9a1997c9a466cf4035dcb78100f1d46d1874eb6d2fc1519541da062"
   },
   "summary": {
     "plan_tasks": 55,

--- a/.aio-agentic-sdlc/changes/drift-triage/report.json
+++ b/.aio-agentic-sdlc/changes/drift-triage/report.json
@@ -1,0 +1,2754 @@
+{
+  "schema_version": 1,
+  "source": {
+    "intention_sha256": "e523f24914615974ab0cd99c3c33a97d63c68fb2a326989a3c3f00560d89f239",
+    "reality_sha256": "23d7307f201f3c49c8d26099c954f42f5ae1efbf9a65aa00a206dae23486594a",
+    "plan_digest": "c8bc15b752513042dd3b8120da48eaeef817315aa787cb1ec394f32d479267ae"
+  },
+  "summary": {
+    "plan_tasks": 55,
+    "missing_implementation": 1,
+    "obsolete_or_unapproved_intent": 52,
+    "framework_tooling_drift": 2,
+    "identity_review_required": 0,
+    "needs_classification": 0,
+    "actionable_implementation": 1
+  },
+  "limit": {
+    "max_items": 100,
+    "total_items": 55,
+    "returned_items": 55,
+    "truncated": false
+  },
+  "items": [
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "DAG Visualization and Comparison",
+        "name_truncated": false
+      },
+      "classification": "missing_implementation",
+      "reason": "The approved visualization acceptance criteria require CLI and MCP visualization surfaces, comparison evidence, and documented review workflow; none exists in the current source or public tool surface.",
+      "decision_source": "explicit",
+      "implementation_authorized": true,
+      "evidence": {
+        "approval_state": "approved",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "DAG-VIS-AC1",
+              "id_truncated": false,
+              "statement": "CLI and MCP operations render deterministic Mermaid and human-readable summaries for an Intention DAG, Reality DAG, or a selected node neighborhood without exposing raw YAML.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:dag-visualization-determinism",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "cli:dag-tool-visualize",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "mcp:visualize-dag",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 3,
+                "returned_items": 3,
+                "truncated": false
+              }
+            },
+            {
+              "id": "DAG-VIS-AC2",
+              "id_truncated": false,
+              "statement": "A comparison view shows intended identity and relationships beside confirmed, candidate, ambiguous, or unmapped Reality evidence, including exact source evidence when available.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:dag-comparison-evidence",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "report:self-dogfood-dag-comparison",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            },
+            {
+              "id": "DAG-VIS-AC3",
+              "id_truncated": false,
+              "statement": "Visualization escapes untrusted labels, applies explicit graph and nested-candidate bounds before output construction, reports complete totals and truncation, and never mutates source or framework state.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:visualization-label-escaping",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "test:visualization-bounds",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "test:visualization-read-only",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 3,
+                "returned_items": 3,
+                "truncated": false
+              }
+            },
+            {
+              "id": "DAG-VIS-AC4",
+              "id_truncated": false,
+              "statement": "The manage-sdlc plugin guides agents to present the visual review before requesting identity approval, with documented CLI and MCP parity.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "validation:manage-sdlc-skill",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "validation:codex-plugin",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "doc:dag-visualization-workflow",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 3,
+                "returned_items": 3,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 4,
+          "returned_items": 4,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+        "canonical_intent_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58"
+      },
+      "decision": {
+        "rationale": "The approved visualization acceptance criteria require CLI and MCP visualization surfaces, comparison evidence, and documented review workflow; none exists in the current source or public tool surface.",
+        "evidence": [
+          "intent:DAG-VIS-AC1-through-DAG-VIS-AC4",
+          "inspection:dag-tool-has-no-visualize-command",
+          "inspection:mcp-server-has-no-visualize-dag-tool"
+        ],
+        "decided_by": "sdlc_cartographer",
+        "decided_at": "2026-08-15T15:53:51.481351-04:00"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Legacy Intent IR Migration",
+        "name_truncated": false
+      },
+      "classification": "framework_tooling_drift",
+      "reason": "Legacy Intent IR migration is implemented and verified as LegacyIntentMigrator, but deterministic reconciliation cannot map the differently named source symbol without an approved source-identity workflow for unmapped intent.",
+      "decision_source": "explicit",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "approved",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "INTENT-MIGRATION-AC1",
+              "id_truncated": false,
+              "statement": "The framework inventories every Intention node without Intent IR and produces a deterministic coverage report with complete totals and bounded detail.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:legacy-intent-inventory",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "report:intent-ir-coverage",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            },
+            {
+              "id": "INTENT-MIGRATION-AC2",
+              "id_truncated": false,
+              "statement": "A migration compiler creates versioned Intent IR from existing local descriptions, relationships, specifications, and provenance without inventing requirements; uncertain interpretations remain review-required.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:legacy-intent-compilation",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "test:uncertain-intent-review-gate",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "report:migration-provenance",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 3,
+                "returned_items": 3,
+                "truncated": false
+              }
+            },
+            {
+              "id": "INTENT-MIGRATION-AC3",
+              "id_truncated": false,
+              "statement": "Each accepted migration is an atomic framework transition that preserves canonical GUIDs, graph edges, prior fields, and revision history and rejects stale writers without partial mutation.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:atomic-intent-migration",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "test:migration-graph-preservation",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "test:migration-stale-writer",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 3,
+                "returned_items": 3,
+                "truncated": false
+              }
+            },
+            {
+              "id": "INTENT-MIGRATION-AC4",
+              "id_truncated": false,
+              "statement": "After migration, strict Intent IR validation succeeds for every node and intent-summary renders each node without requiring raw YAML inspection.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "validation:strict-intent-ir",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "test:intent-summary-complete-coverage",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 4,
+          "returned_items": 4,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:f4658dd7-1ea1-5e1f-b851-2a376cc1649a",
+        "canonical_intent_id": "f4658dd7-1ea1-5e1f-b851-2a376cc1649a"
+      },
+      "decision": {
+        "rationale": "Legacy Intent IR migration is implemented and verified as LegacyIntentMigrator, but deterministic reconciliation cannot map the differently named source symbol without an approved source-identity workflow for unmapped intent.",
+        "evidence": [
+          "source:src/aio_agentic_sdlc/intent_migration.py#LegacyIntentMigrator",
+          "tests:tests/test_intent_migration.py",
+          "artifact:.aio-agentic-sdlc/changes/legacy-intent-ir-migration/result.json"
+        ],
+        "decided_by": "sdlc_cartographer",
+        "decided_at": "2026-08-15T15:53:51.481351-04:00"
+      }
+    },
+    {
+      "subject": {
+        "kind": "relationship",
+        "source": {
+          "type": "component",
+          "name": "Approval-Gated Source Mapping",
+          "name_truncated": false
+        },
+        "relation": "depends_on",
+        "target": {
+          "type": "component",
+          "name": "Evidence-Gated Reconciliation Baseline",
+          "name_truncated": false
+        }
+      },
+      "classification": "framework_tooling_drift",
+      "reason": "The current Reality parser does not emit depends_on relationships for component-to-component endpoints.",
+      "decision_source": "observation_contract",
+      "implementation_authorized": false,
+      "evidence": {
+        "source_approval_state": "approved",
+        "target_approval_state": "approved",
+        "safe_action": "connect_confirmed",
+        "relationship_observable": false
+      },
+      "audit": {
+        "subject_key": "relationship:6317643a-a8fc-5026-b373-9330004bc90d:depends_on:9015c8a3-fd14-5598-916d-d03fcf41e415",
+        "source_intent_id": "6317643a-a8fc-5026-b373-9330004bc90d",
+        "target_intent_id": "9015c8a3-fd14-5598-916d-d03fcf41e415"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "agent",
+        "name": "SDLC Architect Agent",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-07e7e16c-c4d7-4f59-ac98-5d33599f0270-AC1",
+              "id_truncated": false,
+              "statement": "Reads PRDs from .aio-agentic-sdlc/inbox/, performs technical research, maps new architectural nodes into .aio-agentic-sdlc/intention-dag.yaml, and moves processed PRDs to .aio-agentic-sdlc/specs/.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:07e7e16c-c4d7-4f59-ac98-5d33599f0270",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:07e7e16c-c4d7-4f59-ac98-5d33599f0270",
+        "canonical_intent_id": "07e7e16c-c4d7-4f59-ac98-5d33599f0270"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "TUI Dashboard",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-09497db1-e4c8-43f3-8c27-ee8577b2b59f-AC1",
+              "id_truncated": false,
+              "statement": "Local terminal UI dashboard providing real-time visibility into the dynamic DAG and parallel swarms.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:09497db1-e4c8-43f3-8c27-ee8577b2b59f",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:09497db1-e4c8-43f3-8c27-ee8577b2b59f",
+        "canonical_intent_id": "09497db1-e4c8-43f3-8c27-ee8577b2b59f"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Daemon Watcher",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-10d4c0ba-de03-49ac-ae0e-41048fd557ed-AC1",
+              "id_truncated": false,
+              "statement": "Long-running background process that monitors the inbox directory for PRDs and triggers pipelines.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:10d4c0ba-de03-49ac-ae0e-41048fd557ed",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:10d4c0ba-de03-49ac-ae0e-41048fd557ed",
+        "canonical_intent_id": "10d4c0ba-de03-49ac-ae0e-41048fd557ed"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "endpoint",
+        "name": "Health Check Endpoint",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-1525a991-0ffa-4f82-b5a1-b23602346ca4-AC1",
+              "id_truncated": false,
+              "statement": "Lightweight health check endpoint for liveness probes",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:1525a991-0ffa-4f82-b5a1-b23602346ca4",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:1525a991-0ffa-4f82-b5a1-b23602346ca4",
+        "canonical_intent_id": "1525a991-0ffa-4f82-b5a1-b23602346ca4"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Cross-language Ontology Portability",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "ONTOLOGY-AC1",
+              "id_truncated": false,
+              "statement": "Python and TypeScript parsers emit the same stable core node and edge ontology.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:cross-language-ontology-contract",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "fixture:mixed-python-typescript-project",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            },
+            {
+              "id": "ONTOLOGY-AC2",
+              "id_truncated": false,
+              "statement": "Language-specific concepts do not leak into the core schema and GUID traceability remains valid across languages.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:mixed-project-guid-traceability",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "review:ontology-boundary",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 2,
+          "returned_items": 2,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:15302505-8828-525a-bebb-f72621f467a1",
+        "canonical_intent_id": "15302505-8828-525a-bebb-f72621f467a1"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "agent",
+        "name": "SDLC Intake Agent",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-22822d50-4438-4b48-821f-451933f557dd-AC1",
+              "id_truncated": false,
+              "statement": "Chats with the user, distills ideas into PRDs, and writes them to .aio-agentic-sdlc/inbox/ safely without writing execution code",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:22822d50-4438-4b48-821f-451933f557dd",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:22822d50-4438-4b48-821f-451933f557dd",
+        "canonical_intent_id": "22822d50-4438-4b48-821f-451933f557dd"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "DAG Schema Migrator",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-2499ec97-aa53-4f54-8a55-5406403a647b-AC1",
+              "id_truncated": false,
+              "statement": "Tooling to migrate existing DAG schema states to enforce strict GUID/Integer node IDs and eliminate fuzzy string matching.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:2499ec97-aa53-4f54-8a55-5406403a647b",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:2499ec97-aa53-4f54-8a55-5406403a647b",
+        "canonical_intent_id": "2499ec97-aa53-4f54-8a55-5406403a647b"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Unified Agent Definitions",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-277fe548-6b99-4711-a89c-b681d262f820-AC1",
+              "id_truncated": false,
+              "statement": "Standardized agent definitions using the unified agent.md format with YAML frontmatter and markdown instructions.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:277fe548-6b99-4711-a89c-b681d262f820",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:277fe548-6b99-4711-a89c-b681d262f820",
+        "canonical_intent_id": "277fe548-6b99-4711-a89c-b681d262f820"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Canonical GUID Extractor",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-2e8a1562-7e77-4402-992f-f461e8c7161f-AC1",
+              "id_truncated": false,
+              "statement": "Extracts 'aio-sdlc-node' UUIDs from code comments via Tree-Sitter and agent frontmatters via PyYAML.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:2e8a1562-7e77-4402-992f-f461e8c7161f",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:2e8a1562-7e77-4402-992f-f461e8c7161f",
+        "canonical_intent_id": "2e8a1562-7e77-4402-992f-f461e8c7161f"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Agent Format Migrator",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-37c790a3-75a2-4533-9384-889a06a9e573-AC1",
+              "id_truncated": false,
+              "statement": "Tooling to scan .agents/agents/ for legacy agent.json and system_prompt.md files, consolidate them into agent.md with YAML frontmatter, and delete the legacy files.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:37c790a3-75a2-4533-9384-889a06a9e573",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:37c790a3-75a2-4533-9384-889a06a9e573",
+        "canonical_intent_id": "37c790a3-75a2-4533-9384-889a06a9e573"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "EULA & Privacy Prompt",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-3ea4e322-7259-4f15-99c8-cbee950afe00-AC1",
+              "id_truncated": false,
+              "statement": "Clickwrap prompt for first-time users to accept the Non-Commercial terms and Privacy Policy.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:3ea4e322-7259-4f15-99c8-cbee950afe00",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:3ea4e322-7259-4f15-99c8-cbee950afe00",
+        "canonical_intent_id": "3ea4e322-7259-4f15-99c8-cbee950afe00"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Approval Gate",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-40566eb0-0911-40cc-a1df-9ff6697734c8-AC1",
+              "id_truncated": false,
+              "statement": "Pauses pipeline before merging for user review, bypassable via configuration.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:40566eb0-0911-40cc-a1df-9ff6697734c8",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:40566eb0-0911-40cc-a1df-9ff6697734c8",
+        "canonical_intent_id": "40566eb0-0911-40cc-a1df-9ff6697734c8"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "endpoint",
+        "name": "Telemetry Backend",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-415fa500-6e50-488d-97ee-39ec4a9b2255-AC1",
+              "id_truncated": false,
+              "statement": "Third-party managed telemetry provider (e.g., PostHog/Sentry).",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:415fa500-6e50-488d-97ee-39ec4a9b2255",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:415fa500-6e50-488d-97ee-39ec4a9b2255",
+        "canonical_intent_id": "415fa500-6e50-488d-97ee-39ec4a9b2255"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Agent Personas Config",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-45b34e7b-3c77-48f9-9b7c-8ec541243767-AC1",
+              "id_truncated": false,
+              "statement": "Configuration for custom names and personalities of user-facing agents, injected into prompts.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:45b34e7b-3c77-48f9-9b7c-8ec541243767",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:45b34e7b-3c77-48f9-9b7c-8ec541243767",
+        "canonical_intent_id": "45b34e7b-3c77-48f9-9b7c-8ec541243767"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "agent",
+        "name": "Implementer Agent",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-48295997-8b54-4168-bccc-30d49ae766d8-AC1",
+              "id_truncated": false,
+              "statement": "Swarm agent that implements SDDs, returning Variance Reports if technical roadblocks occur.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:48295997-8b54-4168-bccc-30d49ae766d8",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:48295997-8b54-4168-bccc-30d49ae766d8",
+        "canonical_intent_id": "48295997-8b54-4168-bccc-30d49ae766d8"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Variance Report Router",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-483abc2c-fab5-460f-9cd7-47bc25e0d3b3-AC1",
+              "id_truncated": false,
+              "statement": "Captures spec pushback from implementers and routes it to the Architect for dynamic SDD revision.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:483abc2c-fab5-460f-9cd7-47bc25e0d3b3",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:483abc2c-fab5-460f-9cd7-47bc25e0d3b3",
+        "canonical_intent_id": "483abc2c-fab5-460f-9cd7-47bc25e0d3b3"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "system",
+        "name": "AIO Agentic SDLC System",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-4d76717e-55cd-4768-b05e-06a3cce1128b-AC1",
+              "id_truncated": false,
+              "statement": "Dual-DAG reconciliation engine for autonomous software development",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:4d76717e-55cd-4768-b05e-06a3cce1128b",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:4d76717e-55cd-4768-b05e-06a3cce1128b",
+        "canonical_intent_id": "4d76717e-55cd-4768-b05e-06a3cce1128b"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Agent Runtime Portability",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "RUNTIME-AC1",
+              "id_truncated": false,
+              "statement": "Runtime-specific agent invocation is isolated behind a stable adapter contract.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:runtime-adapter-contract",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "architecture:runtime-boundary",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            },
+            {
+              "id": "RUNTIME-AC2",
+              "id_truncated": false,
+              "statement": "Codex-native orchestration advances one selected task through its lifecycle without modifying canonical intent semantics.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:codex-orchestration-lifecycle",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "demo:two-runtime-state-compatibility",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 2,
+          "returned_items": 2,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:4f6cdecf-639d-50e5-bc6d-ad71c1750000",
+        "canonical_intent_id": "4f6cdecf-639d-50e5-bc6d-ad71c1750000"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "agent",
+        "name": "Specialized QA Agents",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-54a600df-269a-42b2-a7e1-62f2a6687169-AC1",
+              "id_truncated": false,
+              "statement": "Swarm of specialized subagents (A11Y, Security, API Contracts, etc.) invoked for domain-specific checks.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:54a600df-269a-42b2-a7e1-62f2a6687169",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:54a600df-269a-42b2-a7e1-62f2a6687169",
+        "canonical_intent_id": "54a600df-269a-42b2-a7e1-62f2a6687169"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "container",
+        "name": "Agentic Orchestrator Loop",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-54b91d55-08fe-48df-be35-445be7cd1e46-AC1",
+              "id_truncated": false,
+              "statement": "Main orchestrator binding the calculated Diff to the SDLC Pipeline",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:54b91d55-08fe-48df-be35-445be7cd1e46",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:54b91d55-08fe-48df-be35-445be7cd1e46",
+        "canonical_intent_id": "54b91d55-08fe-48df-be35-445be7cd1e46"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Artifact Templating Engine",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-5a81e63d-85c7-4704-a0b1-e076367b2fd1-AC1",
+              "id_truncated": false,
+              "statement": "Programmatically generates standardized documentation artifacts from structured data.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:5a81e63d-85c7-4704-a0b1-e076367b2fd1",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:5a81e63d-85c7-4704-a0b1-e076367b2fd1",
+        "canonical_intent_id": "5a81e63d-85c7-4704-a0b1-e076367b2fd1"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Conflict Resolution Manager",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-5a916efe-75ec-4b0d-a8de-79fcd8e5035c-AC1",
+              "id_truncated": false,
+              "statement": "Detects and resolves DAG and file-level merge conflicts across parallel execution tasks.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:5a916efe-75ec-4b0d-a8de-79fcd8e5035c",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:5a916efe-75ec-4b0d-a8de-79fcd8e5035c",
+        "canonical_intent_id": "5a916efe-75ec-4b0d-a8de-79fcd8e5035c"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Unified Configuration File",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-64b5afea-5e38-4659-82bb-662be3f3458e-AC1",
+              "id_truncated": false,
+              "statement": "Project-local configuration at .aio-agentic-sdlc/config.json, replacing legacy external tracker configuration.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:64b5afea-5e38-4659-82bb-662be3f3458e",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:64b5afea-5e38-4659-82bb-662be3f3458e",
+        "canonical_intent_id": "64b5afea-5e38-4659-82bb-662be3f3458e"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Explicit Evidence Model",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "EVIDENCE-AC1",
+              "id_truncated": false,
+              "statement": "Completion distinguishes declared, mapped, structural, tested, behaviorally verified, and approved evidence levels.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:evidence-level-state-machine",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "schema:evidence-v1",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            },
+            {
+              "id": "EVIDENCE-AC2",
+              "id_truncated": false,
+              "statement": "Reconciliation reports cite supporting evidence and list acceptance criteria that remain unverified.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:reconciliation-evidence-report",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "demo:traceability-report",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 2,
+          "returned_items": 2,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:6b1b3459-38a0-5cd5-8ff4-1453f17c3d76",
+        "canonical_intent_id": "6b1b3459-38a0-5cd5-8ff4-1453f17c3d76"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Research Spikes Directory",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-6ff0c1eb-b872-4036-987b-20988d9b380f-AC1",
+              "id_truncated": false,
+              "statement": "Output location for Research Spikes generated by the Researcher Agent.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:6ff0c1eb-b872-4036-987b-20988d9b380f",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:6ff0c1eb-b872-4036-987b-20988d9b380f",
+        "canonical_intent_id": "6ff0c1eb-b872-4036-987b-20988d9b380f"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "module",
+        "name": "AST Visitor",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-7418a0a0-0d7e-45ba-94a3-b388cfa0ec5f-AC1",
+              "id_truncated": false,
+              "statement": "Traverses parsed ASTs (or YAML data) and constructs Reality DAG Nodes.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:7418a0a0-0d7e-45ba-94a3-b388cfa0ec5f",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:7418a0a0-0d7e-45ba-94a3-b388cfa0ec5f",
+        "canonical_intent_id": "7418a0a0-0d7e-45ba-94a3-b388cfa0ec5f"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Operational Modes Config",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-7b029abd-1321-4cd7-9c1d-9e9f7b62046c-AC1",
+              "id_truncated": false,
+              "statement": "Configuration for approval gates vs bypass mode for continuous delivery",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:7b029abd-1321-4cd7-9c1d-9e9f7b62046c",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:7b029abd-1321-4cd7-9c1d-9e9f7b62046c",
+        "canonical_intent_id": "7b029abd-1321-4cd7-9c1d-9e9f7b62046c"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Intent IR v1",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "INTENT-IR-AC1",
+              "id_truncated": false,
+              "statement": "Intent nodes preserve source provenance, assumptions, ambiguities, bounded confidence, evidence requirements, revision history, ownership, and approval state in a versioned schema.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:intent-ir-schema-validation",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "adr:0002-intent-ir-v1",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            },
+            {
+              "id": "INTENT-IR-AC2",
+              "id_truncated": false,
+              "statement": "Agents can create, revise, validate, and review Intent IR through protected framework operations without editing raw YAML.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:intent-ir-protected-mutation",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "cli:dag-tool-intent",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "mcp:create-set-validate-review-intent",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 3,
+                "returned_items": 3,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 2,
+          "returned_items": 2,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:7bcd1683-2a10-5cbc-ab91-440ea920eaf1",
+        "canonical_intent_id": "7bcd1683-2a10-5cbc-ab91-440ea920eaf1"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Product Hardening",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "HARDENING-AC1",
+              "id_truncated": false,
+              "statement": "A clean environment can install and validate the CLI, MCP server, and Codex plugin through stable documented contracts.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "ci:clean-install-matrix",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "test:plugin-install-smoke",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "artifact:release-contract-documentation",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 3,
+                "returned_items": 3,
+                "truncated": false
+              }
+            },
+            {
+              "id": "HARDENING-AC2",
+              "id_truncated": false,
+              "statement": "The repository contains a deliberate license, recovery procedures, and evidence-backed dogfooding reports understandable to external adopters.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "file:LICENSE",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "doc:recovery-procedure",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "report:dogfooding-evidence",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 3,
+                "returned_items": 3,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 2,
+          "returned_items": 2,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:82579715-d088-51ac-999f-4a95235b561c",
+        "canonical_intent_id": "82579715-d088-51ac-999f-4a95235b561c"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Commercial Licensing Enforcer",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-900f5127-2c5e-46e1-890e-991ef7b27043-AC1",
+              "id_truncated": false,
+              "statement": "Validates commercial usage via license keys against an external Merchant of Record API.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:900f5127-2c5e-46e1-890e-991ef7b27043",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:900f5127-2c5e-46e1-890e-991ef7b27043",
+        "canonical_intent_id": "900f5127-2c5e-46e1-890e-991ef7b27043"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Parallel Task Runner",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-9066081a-24ea-4937-9f47-5ba87e09f731-AC1",
+              "id_truncated": false,
+              "statement": "Spawns concurrent subagents for unblocked items in the backlog, handling DAG concurrency and merge conflicts",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:9066081a-24ea-4937-9f47-5ba87e09f731",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:9066081a-24ea-4937-9f47-5ba87e09f731",
+        "canonical_intent_id": "9066081a-24ea-4937-9f47-5ba87e09f731"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Archive Directory",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-908d2539-0567-41cd-9d34-260e1ef345a1-AC1",
+              "id_truncated": false,
+              "statement": "Storage for successfully processed Product Requirement Documents (PRDs).",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:908d2539-0567-41cd-9d34-260e1ef345a1",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:908d2539-0567-41cd-9d34-260e1ef345a1",
+        "canonical_intent_id": "908d2539-0567-41cd-9d34-260e1ef345a1"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Version Command",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-989b390d-aa2a-4cdc-8dc5-593b76c4b08b-AC1",
+              "id_truncated": false,
+              "statement": "CLI and MCP entrypoint for safely reporting framework version before initialization.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:989b390d-aa2a-4cdc-8dc5-593b76c4b08b",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:989b390d-aa2a-4cdc-8dc5-593b76c4b08b",
+        "canonical_intent_id": "989b390d-aa2a-4cdc-8dc5-593b76c4b08b"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Telemetry Module",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-a187faf6-c03a-4657-9ac6-9319e51499b8-AC1",
+              "id_truncated": false,
+              "statement": "Lightweight client for collecting anonymized usage metrics and crash reports, opt-out enabled.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:a187faf6-c03a-4657-9ac6-9319e51499b8",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:a187faf6-c03a-4657-9ac6-9319e51499b8",
+        "canonical_intent_id": "a187faf6-c03a-4657-9ac6-9319e51499b8"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Templates Directory",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-a6cf0410-832b-4597-a505-8fd5eb90d367-AC1",
+              "id_truncated": false,
+              "statement": "Centralized storage for structured Markdown templates (PRD, SDD, Research Spike).",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:a6cf0410-832b-4597-a505-8fd5eb90d367",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:a6cf0410-832b-4597-a505-8fd5eb90d367",
+        "canonical_intent_id": "a6cf0410-832b-4597-a505-8fd5eb90d367"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Markdown Parser",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-a937dc0f-c261-461a-975f-03950289be88-AC1",
+              "id_truncated": false,
+              "statement": "Parses Markdown files to extract YAML frontmatter for agent configuration.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:a937dc0f-c261-461a-975f-03950289be88",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:a937dc0f-c261-461a-975f-03950289be88",
+        "canonical_intent_id": "a937dc0f-c261-461a-975f-03950289be88"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Subagent Output Templates",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-b4e6a8f3-a7f7-489e-8192-6d969a8fa6dd-AC1",
+              "id_truncated": false,
+              "statement": "Structured reporting templates for each subagent so the Orchestrator can compile a clean, human-readable summary of the entire parallel session.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:b4e6a8f3-a7f7-489e-8192-6d969a8fa6dd",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:b4e6a8f3-a7f7-489e-8192-6d969a8fa6dd",
+        "canonical_intent_id": "b4e6a8f3-a7f7-489e-8192-6d969a8fa6dd"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Session Report Compiler",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-b9c4304e-70cd-47de-a94c-dcfbbca66335-AC1",
+              "id_truncated": false,
+              "statement": "Compiles structured subagent templates into unified Markdown session summaries.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:b9c4304e-70cd-47de-a94c-dcfbbca66335",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:b9c4304e-70cd-47de-a94c-dcfbbca66335",
+        "canonical_intent_id": "b9c4304e-70cd-47de-a94c-dcfbbca66335"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "agent",
+        "name": "SDLC Researcher Agent",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-bcb5855b-46cf-475c-bf5c-5267a124e58a-AC1",
+              "id_truncated": false,
+              "statement": "Dedicated subagent spawned by the Architect to perform deep technical research and draft spikes.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:bcb5855b-46cf-475c-bf5c-5267a124e58a",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:bcb5855b-46cf-475c-bf5c-5267a124e58a",
+        "canonical_intent_id": "bcb5855b-46cf-475c-bf5c-5267a124e58a"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Specs Directory",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-c2d35f1b-2d6c-43db-9c54-91f1f5d125f2-AC1",
+              "id_truncated": false,
+              "statement": "Directory storing deterministic Markdown Software Design Documents natively bound to the DAG.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:c2d35f1b-2d6c-43db-9c54-91f1f5d125f2",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:c2d35f1b-2d6c-43db-9c54-91f1f5d125f2",
+        "canonical_intent_id": "c2d35f1b-2d6c-43db-9c54-91f1f5d125f2"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Closed-loop Reference Demo",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "DEMO-AC1",
+              "id_truncated": false,
+              "statement": "A fresh checkout reproduces one requirement through intent, implementation, tests, evidence, and approval.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "demo:closed-loop-reproduction-script",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "test:closed-loop-integration",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            },
+            {
+              "id": "DEMO-AC2",
+              "id_truncated": false,
+              "statement": "The resulting traceability report is understandable without knowledge of framework internals.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "artifact:human-readable-traceability-report",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "review:external-reader-usability",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 2,
+          "returned_items": 2,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:cb02a996-6d3f-5610-9043-b1e768587d84",
+        "canonical_intent_id": "cb02a996-6d3f-5610-9043-b1e768587d84"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "container",
+        "name": "DAG Engine Container",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-cb432b58-db06-4d49-a6ab-c11c9e86bcc2-AC1",
+              "id_truncated": false,
+              "statement": "Core container for DAG management and difference calculation",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:cb432b58-db06-4d49-a6ab-c11c9e86bcc2",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:cb432b58-db06-4d49-a6ab-c11c9e86bcc2",
+        "canonical_intent_id": "cb432b58-db06-4d49-a6ab-c11c9e86bcc2"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Inbox Directory",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-d4049c0c-4bf8-4d13-94b6-5e5410190f49-AC1",
+              "id_truncated": false,
+              "statement": "Directory containing new, unprocessed Product Requirement Documents (PRDs).",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:d4049c0c-4bf8-4d13-94b6-5e5410190f49",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:d4049c0c-4bf8-4d13-94b6-5e5410190f49",
+        "canonical_intent_id": "d4049c0c-4bf8-4d13-94b6-5e5410190f49"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "Intent Translation Benchmark",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "BENCHMARK-AC1",
+              "id_truncated": false,
+              "statement": "A versioned golden corpus covers requirements, constraints, dependencies, ambiguities, evidence, and correction after feedback.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "fixture:intent-translation-golden-corpus",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "review:golden-case-approval",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            },
+            {
+              "id": "BENCHMARK-AC2",
+              "id_truncated": false,
+              "statement": "CI reports omissions, inventions, incorrect dependencies, unjustified completion claims, repeated-run stability, and correction quality against explicit thresholds.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "test:intent-translation-benchmark",
+                    "value_truncated": false
+                  },
+                  {
+                    "value": "ci:intent-quality-thresholds",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 2,
+                "returned_items": 2,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 2,
+          "returned_items": 2,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:d64fbc3a-bdde-5672-8645-4aaa75464e46",
+        "canonical_intent_id": "d64fbc3a-bdde-5672-8645-4aaa75464e46"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "endpoint",
+        "name": "Merchant of Record API",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-da3ee4cb-c37b-40f1-a1c4-93c24822e597-AC1",
+              "id_truncated": false,
+              "statement": "External API (e.g., Lemon Squeezy/Paddle) to validate keys and manage software monetization.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:da3ee4cb-c37b-40f1-a1c4-93c24822e597",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:da3ee4cb-c37b-40f1-a1c4-93c24822e597",
+        "canonical_intent_id": "da3ee4cb-c37b-40f1-a1c4-93c24822e597"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "entity",
+        "name": "Shared State Store",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-ea4ceb31-1218-43b9-becc-333e69e98abe-AC1",
+              "id_truncated": false,
+              "statement": "Local state tracking mechanism to feed the TUI dashboard live updates.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:ea4ceb31-1218-43b9-becc-333e69e98abe",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:ea4ceb31-1218-43b9-becc-333e69e98abe",
+        "canonical_intent_id": "ea4ceb31-1218-43b9-becc-333e69e98abe"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "container",
+        "name": "MCP Server",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-f1009cfe-9cde-4260-9235-72886d71fa94-AC1",
+              "id_truncated": false,
+              "statement": "Primary MCP-First interface for agents, exposing dynamic resources (e.g., the diff backlog) and core tools.",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:f1009cfe-9cde-4260-9235-72886d71fa94",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:f1009cfe-9cde-4260-9235-72886d71fa94",
+        "canonical_intent_id": "f1009cfe-9cde-4260-9235-72886d71fa94"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "component",
+        "name": "CLI Entrypoint",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-f24b7477-032b-4f93-abcf-9b1c70627900-AC1",
+              "id_truncated": false,
+              "statement": "Exposes plan and apply commands to run the DiffingEngine and Orchestrator Loop",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:f24b7477-032b-4f93-abcf-9b1c70627900",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:f24b7477-032b-4f93-abcf-9b1c70627900",
+        "canonical_intent_id": "f24b7477-032b-4f93-abcf-9b1c70627900"
+      }
+    },
+    {
+      "subject": {
+        "kind": "intent",
+        "type": "module",
+        "name": "QA Swarm Orchestrator",
+        "name_truncated": false
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "Intent approval state is review_required; implementation is withheld until the canonical intent is approved or retired.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "approval_state": "review_required",
+        "safe_action": "investigate_intent",
+        "acceptance_criteria": {
+          "items": [
+            {
+              "id": "LEGACY-f4d2f082-e822-4aa6-b74d-38b14bd84c87-AC1",
+              "id_truncated": false,
+              "statement": "Manages a swarm of specialized QA subagents to ensure bulletproof code generation",
+              "statement_truncated": false,
+              "required_evidence": {
+                "items": [
+                  {
+                    "value": "reconciliation:intent:f4d2f082-e822-4aa6-b74d-38b14bd84c87",
+                    "value_truncated": false
+                  }
+                ],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": false
+              }
+            }
+          ],
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "audit": {
+        "subject_key": "intent:f4d2f082-e822-4aa6-b74d-38b14bd84c87",
+        "canonical_intent_id": "f4d2f082-e822-4aa6-b74d-38b14bd84c87"
+      }
+    },
+    {
+      "subject": {
+        "kind": "relationship",
+        "source": {
+          "type": "component",
+          "name": "Reality DAG Generator",
+          "name_truncated": false
+        },
+        "relation": "contains",
+        "target": {
+          "type": "component",
+          "name": "Parser Factory",
+          "name_truncated": false
+        }
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "At least one relationship endpoint is not approved; no implementation work may be inferred from the missing observation.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "source_approval_state": "review_required",
+        "target_approval_state": "review_required",
+        "safe_action": "connect_confirmed",
+        "relationship_observable": true
+      },
+      "audit": {
+        "subject_key": "relationship:0fea8fea-9a23-404b-a16b-a9c9c3990e1b:contains:d0307d83-371e-4bb6-925d-84a4b70beb6b",
+        "source_intent_id": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b",
+        "target_intent_id": "d0307d83-371e-4bb6-925d-84a4b70beb6b"
+      }
+    },
+    {
+      "subject": {
+        "kind": "relationship",
+        "source": {
+          "type": "component",
+          "name": "Parser Factory",
+          "name_truncated": false
+        },
+        "relation": "calls",
+        "target": {
+          "type": "component",
+          "name": "Tree-Sitter Parser",
+          "name_truncated": false
+        }
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "At least one relationship endpoint is not approved; no implementation work may be inferred from the missing observation.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "source_approval_state": "review_required",
+        "target_approval_state": "review_required",
+        "safe_action": "connect_confirmed",
+        "relationship_observable": false
+      },
+      "audit": {
+        "subject_key": "relationship:d0307d83-371e-4bb6-925d-84a4b70beb6b:calls:9865715b-99a5-4dcb-ba92-90b03cc3cf1c",
+        "source_intent_id": "d0307d83-371e-4bb6-925d-84a4b70beb6b",
+        "target_intent_id": "9865715b-99a5-4dcb-ba92-90b03cc3cf1c"
+      }
+    },
+    {
+      "subject": {
+        "kind": "relationship",
+        "source": {
+          "type": "component",
+          "name": "Diffing Engine",
+          "name_truncated": false
+        },
+        "relation": "depends_on",
+        "target": {
+          "type": "component",
+          "name": "Reality DAG Generator",
+          "name_truncated": false
+        }
+      },
+      "classification": "obsolete_or_unapproved_intent",
+      "reason": "At least one relationship endpoint is not approved; no implementation work may be inferred from the missing observation.",
+      "decision_source": "approval_gate",
+      "implementation_authorized": false,
+      "evidence": {
+        "source_approval_state": "review_required",
+        "target_approval_state": "review_required",
+        "safe_action": "connect_confirmed",
+        "relationship_observable": false
+      },
+      "audit": {
+        "subject_key": "relationship:fa35fa8a-b6b5-40ca-9080-b31421117e37:depends_on:0fea8fea-9a23-404b-a16b-a9c9c3990e1b",
+        "source_intent_id": "fa35fa8a-b6b5-40ca-9080-b31421117e37",
+        "target_intent_id": "0fea8fea-9a23-404b-a16b-a9c9c3990e1b"
+      }
+    }
+  ]
+}

--- a/.aio-agentic-sdlc/changes/drift-triage/sdd.md
+++ b/.aio-agentic-sdlc/changes/drift-triage/sdd.md
@@ -1,0 +1,65 @@
+---
+document_type: sdd
+title: "Evidence-Bound Reconciliation Drift Triage"
+author: "sdlc_architect"
+date: "2026-08-15"
+related_prd: ".aio-agentic-sdlc/specs/bootstrapping-legacy-reingestion/prd.md"
+node_id: "9015c8a3-fd14-5598-916d-d03fcf41e415"
+
+---
+# Evidence-Bound Reconciliation Drift Triage
+
+## 1. Architecture Overview
+
+Add a deterministic, read-only triage layer between safe reconciliation and backlog execution.
+It classifies every retained safe-plan subject as missing implementation, obsolete or unapproved
+intent, framework-tooling drift, identity review, or still needing classification. Non-approved
+intent can never authorize implementation. Explicit decisions are bound to canonical Intention and
+Reality content through a reproducible plan digest.
+
+### Acceptance criteria
+
+- TRIAGE-AC1: Every safe-plan subject is routed without converting non-approved intent into coding work.
+- TRIAGE-AC2: Explicit decisions are schema-valid, auditable, and stale after either canonical DAG changes.
+- TRIAGE-AC3: Human output is name-first and GUID-last; JSON output has complete totals and bounded nested evidence.
+- TRIAGE-AC4: CLI and MCP expose the same read-only contract, and report output cannot overwrite inputs or protected state.
+
+### Test strategy
+
+Exercise approved and review-required intent, supported and unsupported relationships, stale,
+duplicate, unused, and inapplicable decisions, canonical hash stability across order and GUID case,
+nested evidence limits, human rendering order, protected output paths, CLI persistence, MCP parity,
+full warning-strict regression tests, and byte-for-byte dogfood regeneration after a package build.
+
+## 2. System Components
+
+1. `DriftTriageEngine` consumes validated DAG managers and the bounded safe plan.
+2. `TriageDecisionSet` validates explicit, timestamped decisions and rejects stale or unused subjects.
+3. CLI and MCP adapters expose the same JSON contract; the CLI also renders a GUID-last human brief.
+4. Derived report writing reuses protected-path and atomic-write safeguards.
+5. The Cartographer supplies explicit decisions only where deterministic routing cannot decide safely.
+
+## 3. Data Model
+
+The report carries canonical DAG hashes, a combined plan digest, complete classification totals,
+bounded items, implementation authorization, reasons, approval evidence, and audit identifiers.
+Review-required, draft, or rejected intent is automatically withheld as
+`obsolete_or_unapproved_intent`. Relationships with non-approved endpoints are likewise withheld.
+Unsupported relationship observation is `framework_tooling_drift`. Approved unmapped intent and
+otherwise observable missing relationships remain `needs_classification` until a matching decision
+set resolves them.
+
+## 4. API Design
+
+`DriftTriageEngine(intention, reality).analyze(decisions=..., max_items=...)` returns the versioned report.
+`dag-tool triage --intention ... --reality ... [--decisions ...] [--format human|json] [--output ...]`
+provides local access. MCP `triage_reconciliation_drift(project_path, decisions_json, max_items)`
+returns the identical JSON result. Output is read-only and never mutates DAG or backlog state.
+
+## 5. Security Considerations
+
+Validate all limits and decision fields, require timezone-aware decision timestamps, and reject
+duplicate, stale, unknown, or inapplicable subject keys. Never permit non-approved intent to authorize
+implementation. Hash validated canonical DAG content rather than checkout bytes. Keep report output
+and embedded acceptance criteria bounded, preserve complete totals, reject protected-state and
+symlink or reparse output aliases, and use atomic replacement for derived JSON evidence.

--- a/.aio-agentic-sdlc/reality-dag.yaml
+++ b/.aio-agentic-sdlc/reality-dag.yaml
@@ -303,6 +303,10 @@ nodes:
   type: component
   name: reconcile
   description: Render a bounded, read-only reconciliation evidence report.
+- id: 65e8c64a-7f28-515f-b34b-d6afa699f8ee
+  type: component
+  name: triage
+  description: Classify safe reconciliation work before backlog execution.
 - id: 0ed46e46-0115-5f0f-91cc-5e79007a6add
   type: component
   name: generate_reality
@@ -504,6 +508,50 @@ nodes:
   type: component
   name: calculate_diff
   description: Calculate a bounded safe plan unless legacy behavior is explicit.
+- id: 2d0bae0f-4c1d-5c6e-a67a-1fa09e6bdd76
+  type: module
+  name: drift_triage.py
+  description: Module src.aio_agentic_sdlc.drift_triage
+- id: 49ad556f-0c37-5169-ab72-a1b9fb63d80f
+  type: component
+  name: DriftClassification
+  description: Permitted explicit reconciliation-drift decisions.
+- id: 4836e754-28bc-5155-88ed-99f746b19dfc
+  type: entity
+  name: TriageDecision
+  description: One auditable decision bound to an exact triage subject.
+- id: 9e84c8e8-8019-50ba-9852-2389a95ae4e4
+  type: component
+  name: require_timezone_aware_timestamp
+  description: Function require_timezone_aware_timestamp
+- id: a00508c0-8d80-5141-9091-fc285bc04464
+  type: entity
+  name: TriageDecisionSet
+  description: Explicit decisions for one exact Intention/Reality plan identity.
+- id: ae27108b-dcad-5db0-9b57-87f79cd1a654
+  type: component
+  name: reject_duplicate_subjects
+  description: Function reject_duplicate_subjects
+- id: 6b59aab2-6bbf-56ca-bbe1-6d9708794bd1
+  type: component
+  name: DriftTriageEngine
+  description: Classify safe reconciliation work without mutating DAG or backlog state.
+- id: 1f8c04f8-491f-540f-b1dc-bd49934fc0e3
+  type: component
+  name: __init__
+  description: Function __init__
+- id: 8e1fd93b-b18e-5bb1-ac83-4e3ffc4d96a6
+  type: component
+  name: source_identity
+  description: Function source_identity
+- id: d98476ca-bfb2-5aab-be2b-e61a1ca5de0a
+  type: component
+  name: analyze
+  description: Return a bounded triage report with complete classification totals.
+- id: e62dee61-dd2b-5342-af0e-1c48e3b1d93d
+  type: component
+  name: render_drift_triage
+  description: Render a GUID-last human brief from a drift triage report.
 - id: 03ab3d9a-beb1-5a32-b3f4-5efdddeee956
   type: module
   name: intent_ir.py
@@ -703,6 +751,10 @@ nodes:
   name: reconcile_dags
   description: Classify Intention/Reality identity evidence without mutating project
     state.
+- id: 264ef644-878c-502b-b4a7-d1a47bb29205
+  type: component
+  name: triage_reconciliation_drift
+  description: Classify safe reconciliation work before backlog execution.
 - id: 93cc7cb1-efa6-5648-9b4c-1214e0602884
   type: component
   name: review_mapping
@@ -1490,6 +1542,46 @@ nodes:
   type: component
   name: test_circular_dependency_resiliency
   description: Function test_circular_dependency_resiliency
+- id: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  type: module
+  name: test_drift_triage.py
+  description: Module tests.test_drift_triage
+- id: 25ff365f-5fac-5e2a-9b5d-5278072a2693
+  type: component
+  name: test_triage_withholds_unapproved_intent_from_implementation
+  description: Function test_triage_withholds_unapproved_intent_from_implementation
+- id: 0429578b-039a-5e7c-a461-08c229c7ed96
+  type: component
+  name: test_approved_unmapped_intent_requires_digest_bound_decision
+  description: Function test_approved_unmapped_intent_requires_digest_bound_decision
+- id: 3adfc0a6-3637-5bfd-9fb9-0001e2700d5d
+  type: component
+  name: test_triage_rejects_stale_duplicate_and_unused_decisions
+  description: Function test_triage_rejects_stale_duplicate_and_unused_decisions
+- id: 46baf04f-dff7-5020-868f-a8acc046b221
+  type: component
+  name: test_triage_routes_relationships_by_approval_and_observability
+  description: Function test_triage_routes_relationships_by_approval_and_observability
+- id: f200d156-5824-5964-b985-33e00409f46e
+  type: component
+  name: test_triage_is_deterministic_bounded_and_human_readable
+  description: Function test_triage_is_deterministic_bounded_and_human_readable
+- id: 95ae57ae-b941-56b3-8199-58a5afe496fd
+  type: component
+  name: test_triage_source_identity_is_canonical_across_order_and_guid_case
+  description: Function test_triage_source_identity_is_canonical_across_order_and_guid_case
+- id: 47b3231a-94ea-51b8-b18c-0361f7ed2525
+  type: component
+  name: test_triage_bounds_nested_acceptance_evidence_and_reports_truncation
+  description: Function test_triage_bounds_nested_acceptance_evidence_and_reports_truncation
+- id: 226512ee-bced-58dd-9c19-c6ca76e89b74
+  type: component
+  name: test_cli_triage_writes_reproducible_report_without_mutating_dags
+  description: Function test_cli_triage_writes_reproducible_report_without_mutating_dags
+- id: 7c97025e-79c9-584c-ac8d-22e34a6d2ea9
+  type: component
+  name: test_cli_triage_refuses_protected_report_output
+  description: Function test_cli_triage_refuses_protected_report_output
 - id: 6a2d84d3-1259-5016-b5ea-82b90183905c
   type: module
   name: test_functional_bug.py
@@ -1888,6 +1980,10 @@ nodes:
   type: component
   name: test_mcp_reconcile_dags_returns_the_same_evidence_report
   description: Function test_mcp_reconcile_dags_returns_the_same_evidence_report
+- id: b7b44ed9-31a7-544d-926d-75dfc6b05c91
+  type: component
+  name: test_mcp_triage_reconciliation_drift_withholds_unapproved_intent
+  description: Function test_mcp_triage_reconciliation_drift_withholds_unapproved_intent
 - id: 88c3cb2c-8920-5b1f-b2fc-83ca5864101e
   type: component
   name: test_mcp_mapping_review_and_approval_use_source_bound_evidence
@@ -2617,6 +2713,9 @@ edges:
   target: 2b77c80b-27d1-5b82-b03c-3d3c7333d62b
   type: contains
 - source: 51038e11-df2c-549d-b731-bd99dd919ed5
+  target: 65e8c64a-7f28-515f-b34b-d6afa699f8ee
+  type: contains
+- source: 51038e11-df2c-549d-b731-bd99dd919ed5
   target: 0ed46e46-0115-5f0f-91cc-5e79007a6add
   type: contains
 - source: 51038e11-df2c-549d-b731-bd99dd919ed5
@@ -2764,6 +2863,39 @@ edges:
   target: 49ec4886-cacf-50a5-ba6b-061df8eb6cf6
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
+  target: 2d0bae0f-4c1d-5c6e-a67a-1fa09e6bdd76
+  type: contains
+- source: 2d0bae0f-4c1d-5c6e-a67a-1fa09e6bdd76
+  target: 49ad556f-0c37-5169-ab72-a1b9fb63d80f
+  type: contains
+- source: 2d0bae0f-4c1d-5c6e-a67a-1fa09e6bdd76
+  target: 4836e754-28bc-5155-88ed-99f746b19dfc
+  type: contains
+- source: 4836e754-28bc-5155-88ed-99f746b19dfc
+  target: 9e84c8e8-8019-50ba-9852-2389a95ae4e4
+  type: contains
+- source: 2d0bae0f-4c1d-5c6e-a67a-1fa09e6bdd76
+  target: a00508c0-8d80-5141-9091-fc285bc04464
+  type: contains
+- source: a00508c0-8d80-5141-9091-fc285bc04464
+  target: ae27108b-dcad-5db0-9b57-87f79cd1a654
+  type: contains
+- source: 2d0bae0f-4c1d-5c6e-a67a-1fa09e6bdd76
+  target: 6b59aab2-6bbf-56ca-bbe1-6d9708794bd1
+  type: contains
+- source: 6b59aab2-6bbf-56ca-bbe1-6d9708794bd1
+  target: 1f8c04f8-491f-540f-b1dc-bd49934fc0e3
+  type: contains
+- source: 6b59aab2-6bbf-56ca-bbe1-6d9708794bd1
+  target: 8e1fd93b-b18e-5bb1-ac83-4e3ffc4d96a6
+  type: contains
+- source: 6b59aab2-6bbf-56ca-bbe1-6d9708794bd1
+  target: d98476ca-bfb2-5aab-be2b-e61a1ca5de0a
+  type: contains
+- source: 2d0bae0f-4c1d-5c6e-a67a-1fa09e6bdd76
+  target: e62dee61-dd2b-5342-af0e-1c48e3b1d93d
+  type: contains
+- source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: 03ab3d9a-beb1-5a32-b3f4-5efdddeee956
   type: contains
 - source: 03ab3d9a-beb1-5a32-b3f4-5efdddeee956
@@ -2909,6 +3041,9 @@ edges:
   type: contains
 - source: 905cfe1d-7c37-50cf-b768-9132c88169e7
   target: a938fadb-83a2-54ff-a2fc-4faa73191a6e
+  type: contains
+- source: 905cfe1d-7c37-50cf-b768-9132c88169e7
+  target: 264ef644-878c-502b-b4a7-d1a47bb29205
   type: contains
 - source: 905cfe1d-7c37-50cf-b768-9132c88169e7
   target: 93cc7cb1-efa6-5648-9b4c-1214e0602884
@@ -3484,6 +3619,36 @@ edges:
   target: 522cc4a4-81fc-5e8e-b176-f90b51e7efe2
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
+  target: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: 25ff365f-5fac-5e2a-9b5d-5278072a2693
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: 0429578b-039a-5e7c-a461-08c229c7ed96
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: 3adfc0a6-3637-5bfd-9fb9-0001e2700d5d
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: 46baf04f-dff7-5020-868f-a8acc046b221
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: f200d156-5824-5964-b985-33e00409f46e
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: 95ae57ae-b941-56b3-8199-58a5afe496fd
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: 47b3231a-94ea-51b8-b18c-0361f7ed2525
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: 226512ee-bced-58dd-9c19-c6ca76e89b74
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: 7c97025e-79c9-584c-ac8d-22e34a6d2ea9
+  type: contains
+- source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: 6a2d84d3-1259-5016-b5ea-82b90183905c
   type: contains
 - source: 6a2d84d3-1259-5016-b5ea-82b90183905c
@@ -3788,6 +3953,9 @@ edges:
   type: contains
 - source: 300b5e69-1e98-5b6b-8aa0-4b84713d76da
   target: 0562a648-29c2-578c-bd36-90bc2e3ea221
+  type: contains
+- source: 300b5e69-1e98-5b6b-8aa0-4b84713d76da
+  target: b7b44ed9-31a7-544d-926d-75dfc6b05c91
   type: contains
 - source: 300b5e69-1e98-5b6b-8aa0-4b84713d76da
   target: 88c3cb2c-8920-5b1f-b2fc-83ca5864101e

--- a/.aio-agentic-sdlc/reality-dag.yaml
+++ b/.aio-agentic-sdlc/reality-dag.yaml
@@ -1546,6 +1546,14 @@ nodes:
   type: module
   name: test_drift_triage.py
   description: Module tests.test_drift_triage
+- id: c2882ba7-1e8f-5a11-91e8-7a95b84894cc
+  type: component
+  name: test_triage_rejects_invalid_dag_structure
+  description: Function test_triage_rejects_invalid_dag_structure
+- id: c2dbebe8-1b45-5d75-a5a3-0c138d073d16
+  type: component
+  name: test_triage_rejects_invalid_reality_dag_structure
+  description: Function test_triage_rejects_invalid_reality_dag_structure
 - id: 25ff365f-5fac-5e2a-9b5d-5278072a2693
   type: component
   name: test_triage_withholds_unapproved_intent_from_implementation
@@ -3620,6 +3628,12 @@ edges:
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: c2882ba7-1e8f-5a11-91e8-7a95b84894cc
+  type: contains
+- source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
+  target: c2dbebe8-1b45-5d75-a5a3-0c138d073d16
   type: contains
 - source: 875f9745-0d66-5dd9-81ef-09a1d7e6595f
   target: 25ff365f-5fac-5e2a-9b5d-5278072a2693

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The `aio-agentic-sdlc` framework includes several built-in features that ensure 
 - **Versioned Local State**: The execution backlog uses explicit schema and revision numbers, atomic replacement, stale-writer protection, and a local transaction audit log.
 - **Auditable Intent IR**: Intention nodes can preserve source provenance, assumptions, ambiguities, confidence, evidence-bound acceptance criteria, revision history, and approval state in a strict versioned schema.
 - **Evidence-Gated Reconciliation**: GUID matches are confirmed deterministically, structural matches remain review candidates, and unmatched Reality observations never become deletion work by default.
+- **Approval-Aware Drift Triage**: Safe-plan work is withheld from implementation until accepted intent, Reality observability, and digest-bound classification evidence agree.
 - **SDLC Scribe Agent**: An automated Scribe agent executes before the DevOps agent steps to ensure user-facing documentation (like this README) stays perfectly aligned with the codebase's true reality.
 
 ## Licensing Note
@@ -156,6 +157,10 @@ uv run dag-tool diff \
   --reality .aio-agentic-sdlc/reality-dag.yaml \
   --max-tasks 100 \
   --max-candidates 20
+uv run dag-tool triage \
+  --intention .aio-agentic-sdlc/intention-dag.yaml \
+  --reality .aio-agentic-sdlc/reality-dag.yaml \
+  --max-items 100
 ```
 
 Both commands are read-only. Safe diffing is the default: it asks for mapping review or additional
@@ -164,6 +169,16 @@ code. The historical structural algorithm requires the explicit `--mode legacy-s
 Both top-level records and nested candidate identities are bounded while complete totals and
 truncation metadata remain visible. Report output refuses to overwrite DAG, backlog, audit, or lock
 state.
+
+Triage is also read-only. It automatically withholds draft, review-required, rejected, or missing
+Intent IR as `obsolete_or_unapproved_intent`; it does not turn those nodes into coding work.
+Relationships whose endpoint intent is unapproved are withheld, and relationship shapes the
+Reality parser cannot emit are classified as `framework_tooling_drift`. Remaining approved gaps
+require a `TriageDecisionSet` whose digest matches the exact validated Intention and Reality
+content. Only an explicit `missing_implementation` decision on approved intent is marked actionable.
+The default human view presents names and reasons first and leaves GUIDs and hashes in its final
+audit section. Use `--format json` for automation, `--decisions <file>` for explicit classifications,
+and `--output <file>` for an atomically written derived report.
 
 Promote one unique Python class or function candidate only through an explicit two-step decision:
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -165,6 +165,14 @@ only through the explicit `legacy-structural` compatibility mode.
 Report writers reject canonical DAG, backlog, transaction-journal, and lock paths. Safe edge work
 canonicalizes endpoint GUIDs, deduplicates logical edges, and sorts them before applying limits.
 
+`DriftTriageEngine` is the read-only gate between that safe plan and execution. It uses canonical,
+line-ending-independent hashes of both validated DAGs to bind explicit decisions to one exact plan
+identity. Non-approved intent and relationships with non-approved endpoints are withheld from
+implementation. Relationship shapes outside the Reality parser's observation contract are routed
+as framework-tooling drift. Approved gaps that remain uncertain require an explicit, timestamped
+decision with concrete evidence; only `missing_implementation` on approved intent is actionable.
+The report retains complete totals while bounding returned items and nested acceptance evidence.
+
 ```powershell
 uv run dag-tool reconcile --intention .aio-agentic-sdlc/intention-dag.yaml `
   --reality .aio-agentic-sdlc/reality-dag.yaml `
@@ -172,6 +180,9 @@ uv run dag-tool reconcile --intention .aio-agentic-sdlc/intention-dag.yaml `
 uv run dag-tool diff --intention .aio-agentic-sdlc/intention-dag.yaml `
   --reality .aio-agentic-sdlc/reality-dag.yaml `
   --max-tasks 100 --max-candidates 20
+uv run dag-tool triage --intention .aio-agentic-sdlc/intention-dag.yaml `
+  --reality .aio-agentic-sdlc/reality-dag.yaml `
+  --max-items 100
 uv run dag-tool diff --intention .aio-agentic-sdlc/intention-dag.yaml `
   --reality .aio-agentic-sdlc/reality-dag.yaml `
   --mode legacy-structural

--- a/doc/codex-plugin.md
+++ b/doc/codex-plugin.md
@@ -67,6 +67,7 @@ prompts include:
 - “Show me the highest-priority unblocked task.”
 - “Generate the Reality DAG and report traceability drift.”
 - “Reconcile the Intention and Reality DAGs without proposing destructive cleanup.”
+- “Triage reconciliation drift and show only approved, evidence-backed implementation work.”
 - “Show me a human-readable mapping decision brief for this candidate.”
 
 For MCP calls, pass the absolute target repository as `project_path`. This is especially important
@@ -79,6 +80,11 @@ API, related tests, and unresolved gaps. GUIDs and the digest are audit inputs s
 substitute for review. The default decision is defer because a structural name/type match does not
 prove responsibility or behavior. Only an explicit human identity-linkage decision permits
 `approve_mapping`; any intervening intent, source, or displayed evidence change invalidates it.
+
+Before implementation, the plugin runs approval-aware drift triage. The human view explains names,
+classifications, and routing reasons before its audit identifiers. Non-approved intent never becomes
+implementation work, unsupported Reality relationships are tooling drift, and uncertain approved
+gaps require a decision set bound to the current Intention and Reality digest.
 
 ## Validate changes
 

--- a/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
+++ b/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aio-agentic-sdlc",
-  "version": "0.21.0",
+  "version": "0.21.0+codex.20260815195955",
   "description": "Run a traceable, dual-DAG software delivery workflow with Codex and the AIO Agentic SDLC MCP tools.",
   "author": {
     "name": "aegolius-labs",
@@ -21,15 +21,19 @@
   "interface": {
     "displayName": "AIO Agentic SDLC",
     "shortDescription": "Traceable dual-DAG planning and delivery",
-    "longDescription": "Plan requirements, prioritize graph-backed work, orchestrate implementation and QA, and reconcile intention with repository reality.",
+    "longDescription": "Plan requirements, prioritize graph-backed work, orchestrate implementation and QA, reconcile intention with repository reality, and triage drift before execution.",
     "developerName": "aegolius-labs",
     "category": "Engineering",
-    "capabilities": ["Read", "Write"],
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
     "websiteURL": "https://github.com/aegolius-labs/aio-agentic-sdlc",
     "defaultPrompt": [
       "Turn this feature idea into a traceable PRD.",
       "Run this change through the agentic SDLC pipeline.",
-      "Show me the highest-priority unblocked task."
+      "Show me the highest-priority unblocked task.",
+      "Triage reconciliation drift and show only approved implementation work."
     ]
   }
 }

--- a/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
+++ b/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
@@ -24,10 +24,7 @@
     "longDescription": "Plan requirements, prioritize graph-backed work, orchestrate implementation and QA, reconcile intention with repository reality, and triage drift before execution.",
     "developerName": "aegolius-labs",
     "category": "Engineering",
-    "capabilities": [
-      "Read",
-      "Write"
-    ],
+    "capabilities": ["Read", "Write"],
     "websiteURL": "https://github.com/aegolius-labs/aio-agentic-sdlc",
     "defaultPrompt": [
       "Turn this feature idea into a traceable PRD.",

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/SKILL.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-sdlc
-description: Manage spec-driven software delivery with the AIO Agentic SDLC dual-DAG backlog and MCP tools. Use when Codex needs to interview for a PRD, detect duplicate requirements, plan or execute a feature through architect/implementer/QA roles, prioritize or update the agentic backlog, generate or reconcile intention and reality DAGs, review or approve source mappings, validate GUID traceability, promote accepted specs, or prepare documentation and delivery.
+description: Manage spec-driven software delivery with the AIO Agentic SDLC dual-DAG backlog and MCP tools. Use when Codex needs to interview for a PRD, detect duplicate requirements, plan or execute a feature through architect/implementer/QA roles, prioritize or update the agentic backlog, generate or reconcile intention and reality DAGs, triage reconciliation drift, review or approve source mappings, validate GUID traceability, promote accepted specs, or prepare documentation and delivery.
 ---
 
 # Manage AIO Agentic SDLC

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
@@ -24,6 +24,12 @@ candidates, and unmatched Reality observations are unclassified rather than dele
 - Intention drift: code exists without accepted intent; route to the architect for validation.
 - Tooling drift: the framework cannot represent or detect the state; record a framework blocker.
 
+Run `triage_reconciliation_drift` before adding reconciliation work to the backlog. Treat its plan
+digest as stale after either canonical DAG changes. Only items classified as
+`missing_implementation` with `implementation_authorized: true` may proceed to implementation.
+Route `obsolete_or_unapproved_intent` to Intake/Architecture and
+`framework_tooling_drift` to framework maintenance; never convert either into product code work.
+
 When reconciliation yields exactly one supported structural candidate, run `review_mapping` and
 present its human decision brief. Ask an authorized human whether the implementation responsibility,
 public surface, documentation, and related-test evidence justify linking the candidate to the

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
@@ -21,8 +21,11 @@ Reconcile intended architecture with repository reality through deterministic to
    approve ambiguous, unmapped, unsupported, stale, or mismatched evidence.
 6. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
 7. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
-8. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
-9. After QA acceptance, use `promote_spec` for the exact accepted artifact.
-10. Re-run reconciliation and traceability validation after promotion or material state changes.
+8. Run `triage_reconciliation_drift` before routing work. Withhold non-approved intent, reject stale
+   decision digests, and send only explicitly actionable missing implementation to the orchestrator.
+9. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
+10. After QA acceptance, use `promote_spec` for the exact accepted artifact.
+11. Re-run reconciliation, triage, and traceability validation after promotion or material state
+    changes.
 
 Return a concise status, affected GUIDs and paths, drift classification, and tool output summary.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
@@ -16,6 +16,7 @@ Tool names may be namespaced by the Codex host. Match them by the operation name
 | Validate GUID links | `validate_traceability` | Use the Python API if MCP is unavailable |
 | Generate Reality DAG | `generate_reality` | `uv run dag-tool generate-reality ...` |
 | Reconcile DAG identity evidence | `reconcile_dags` | `uv run dag-tool reconcile ...` |
+| Triage reconciliation drift | `triage_reconciliation_drift` | `uv run dag-tool triage ...` |
 | Review a source mapping | `review_mapping` | `uv run dag-tool mapping review ...` |
 | Approve an exact reviewed mapping | `approve_mapping` | `uv run dag-tool mapping approve ...` |
 | Create intent node | `create_intent_node` | `uv run dag-tool intent create-node ...` |
@@ -32,6 +33,13 @@ root so its containment checks apply to the target repository instead of the MCP
 
 Treat warnings and string results beginning with `Error:` as failed operations. Re-read state after
 a write before claiming success. Do not fall back to manual edits for protected state.
+
+Run drift triage after safe reconciliation and before creating or selecting implementation work.
+Review-required, draft, rejected, or missing Intent IR cannot authorize implementation. Explicit
+triage decisions must match the current plan digest and include concrete evidence, an actor, and a
+timezone-aware timestamp. Only `missing_implementation` on approved intent may be routed to the
+implementer; tooling drift goes to the framework, and obsolete or unapproved intent goes back to
+Intake/Architecture.
 
 Mapping is a two-step approval gate. Run `review_mapping` immediately before presenting a decision.
 Present the decision brief first: intended responsibility and acceptance criteria, actual symbol

--- a/src/aio_agentic_sdlc/dag_cli.py
+++ b/src/aio_agentic_sdlc/dag_cli.py
@@ -11,9 +11,15 @@ from aio_agentic_sdlc.dag_models import Edge, EdgeType, Node, NodeType
 from aio_agentic_sdlc.dag_store import (
     dag_file_lock,
     guarded_dag_path,
+    guarded_file_path,
     mutate_dag_file,
 )
 from aio_agentic_sdlc.diffing_engine import DiffingEngine, DiffPolicy
+from aio_agentic_sdlc.drift_triage import (
+    DriftTriageEngine,
+    TriageDecisionSet,
+    render_drift_triage,
+)
 from aio_agentic_sdlc.intent_ir import IntentIR
 from aio_agentic_sdlc.intent_migration import LegacyIntentMigrator
 from aio_agentic_sdlc.intent_store import create_intent_node_file, update_intent_file
@@ -561,6 +567,81 @@ def reconcile(intention, reality, max_items, max_candidates, output):
             click.echo(json.dumps(report, indent=2))
     except Exception as e:
         click.secho(f"Error reconciling DAGs: {str(e)}", err=True, fg="red")
+        sys.exit(1)
+
+
+@cli.command("triage")
+@click.option(
+    "--intention",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to the canonical Intention DAG yaml file.",
+)
+@click.option(
+    "--reality",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to the generated Reality DAG yaml file.",
+)
+@click.option(
+    "--decisions",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Optional digest-bound JSON triage decisions.",
+)
+@click.option(
+    "--max-items",
+    type=click.IntRange(min=1),
+    default=100,
+    show_default=True,
+    help="Maximum triage records returned without hiding complete totals.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["human", "json"], case_sensitive=False),
+    default="human",
+    show_default=True,
+    help="Render a human brief or the complete machine report.",
+)
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False),
+    help="Atomically write the JSON report instead of printing it.",
+)
+def triage(intention, reality, decisions, max_items, output_format, output):
+    """Classify safe reconciliation work before backlog execution."""
+
+    try:
+        intent_manager = DAGManager.load(intention)
+        reality_manager = DAGManager.load(reality)
+        decision_set = None
+        if decisions:
+            decision_path = guarded_file_path(decisions)
+            decision_set = TriageDecisionSet.model_validate_json(
+                decision_path.read_text(encoding="utf-8")
+            )
+        report = DriftTriageEngine(intent_manager, reality_manager).analyze(
+            decisions=decision_set,
+            max_items=max_items,
+        )
+        if output:
+            protected_paths = [intention, reality]
+            if decisions:
+                protected_paths.append(decisions)
+            write_reconciliation_report(
+                report,
+                output,
+                protected_paths=tuple(protected_paths),
+            )
+            click.echo(f"Drift triage report saved to {output}.")
+        elif output_format.casefold() == "json":
+            click.echo(json.dumps(report, indent=2))
+        else:
+            click.echo(render_drift_triage(report))
+    except Exception as e:
+        click.secho(
+            f"Error triaging reconciliation drift: {str(e)}", err=True, fg="red"
+        )
         sys.exit(1)
 
 

--- a/src/aio_agentic_sdlc/diffing_engine.py
+++ b/src/aio_agentic_sdlc/diffing_engine.py
@@ -246,7 +246,12 @@ class DiffingEngine:
                     {
                         "action": "connect_confirmed",
                         "evidence": {
-                            "confirmed_endpoint_ids": [edge_key[0], edge_key[1]]
+                            "confirmed_endpoint_ids": [edge_key[0], edge_key[1]],
+                            "relationship": {
+                                "source_id": edge_key[0],
+                                "target_id": edge_key[1],
+                                "type": edge.type.value,
+                            },
                         },
                     }
                 )

--- a/src/aio_agentic_sdlc/drift_triage.py
+++ b/src/aio_agentic_sdlc/drift_triage.py
@@ -1,0 +1,565 @@
+"""Evidence-bound routing between safe reconciliation and implementation work."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import EdgeType, Node, NodeType
+from aio_agentic_sdlc.diffing_engine import DiffingEngine, DiffPolicy
+from aio_agentic_sdlc.intent_ir import ApprovalState
+
+TRIAGE_SCHEMA_VERSION = 1
+DEFAULT_MAX_ITEMS = 100
+MAX_CRITERIA = 10
+MAX_REQUIRED_EVIDENCE = 10
+MAX_DISPLAY_TEXT = 500
+
+DecisionText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=2000),
+]
+EvidenceText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=500),
+]
+
+
+class DriftClassification(str, Enum):
+    """Permitted explicit reconciliation-drift decisions."""
+
+    MISSING_IMPLEMENTATION = "missing_implementation"
+    OBSOLETE_OR_UNAPPROVED_INTENT = "obsolete_or_unapproved_intent"
+    FRAMEWORK_TOOLING_DRIFT = "framework_tooling_drift"
+
+
+class TriageDecision(BaseModel):
+    """One auditable decision bound to an exact triage subject."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    subject_key: DecisionText
+    classification: DriftClassification
+    rationale: DecisionText
+    evidence: list[EvidenceText] = Field(min_length=1, max_length=20)
+    decided_by: DecisionText
+    decided_at: datetime
+
+    @field_validator("decided_at")
+    @classmethod
+    def require_timezone_aware_timestamp(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("decided_at must be timezone-aware")
+        return value
+
+
+class TriageDecisionSet(BaseModel):
+    """Explicit decisions for one exact Intention/Reality plan identity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    plan_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    decisions: list[TriageDecision] = Field(default_factory=list, max_length=10000)
+
+    @model_validator(mode="after")
+    def reject_duplicate_subjects(self):
+        keys = [decision.subject_key for decision in self.decisions]
+        if len(keys) != len(set(keys)):
+            raise ValueError("triage decisions contain duplicate subject_key values")
+        return self
+
+
+def _canonical_json(payload: Any) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _feed_digest(digest, label: str, payload: Any) -> None:
+    encoded = _canonical_json({"label": label, "payload": payload})
+    digest.update(len(encoded).to_bytes(8, "big"))
+    digest.update(encoded)
+
+
+def _canonical_dag_sha256(manager: DAGManager) -> str:
+    """Hash validated DAG content independently of YAML order and line endings."""
+
+    canonical_nodes: dict[str, Node] = {}
+    for source_id, node in manager.nodes.items():
+        canonical_id = str(UUID(source_id))
+        if canonical_id in canonical_nodes:
+            raise ValueError(f"DAG contains duplicate canonical GUID {canonical_id}")
+        canonical_nodes[canonical_id] = node
+
+    digest = hashlib.sha256()
+    _feed_digest(
+        digest,
+        "metadata",
+        manager.metadata.model_dump(mode="json", exclude_none=True),
+    )
+    for canonical_id in sorted(canonical_nodes):
+        payload = canonical_nodes[canonical_id].model_dump(
+            mode="json",
+            exclude_none=True,
+        )
+        payload["id"] = canonical_id
+        _feed_digest(digest, "node", payload)
+
+    canonical_edges = []
+    for edge in manager.edges:
+        payload = edge.model_dump(mode="json", exclude_none=True)
+        payload["source"] = str(UUID(edge.source))
+        payload["target"] = str(UUID(edge.target))
+        canonical_edges.append(payload)
+    for payload in sorted(
+        canonical_edges,
+        key=lambda item: (
+            item["source"],
+            item["target"],
+            item["type"],
+            item.get("description", ""),
+        ),
+    ):
+        _feed_digest(digest, "edge", payload)
+    return digest.hexdigest()
+
+
+def _bounded_text(value: str, *, limit: int = MAX_DISPLAY_TEXT) -> tuple[str, bool]:
+    if len(value) <= limit:
+        return value, False
+    return value[:limit], True
+
+
+def _bounded_strings(values: list[str], *, limit: int) -> dict[str, Any]:
+    retained = []
+    for value in values[:limit]:
+        text, truncated = _bounded_text(value)
+        retained.append({"value": text, "value_truncated": truncated})
+    return {
+        "items": retained,
+        "total_items": len(values),
+        "returned_items": len(retained),
+        "truncated": len(retained) < len(values),
+    }
+
+
+def _acceptance_criteria(node: Node) -> dict[str, Any]:
+    criteria = node.intent.acceptance_criteria if node.intent else []
+    retained = []
+    for criterion in criteria[:MAX_CRITERIA]:
+        statement, statement_truncated = _bounded_text(criterion.statement)
+        evidence = _bounded_strings(
+            list(criterion.required_evidence),
+            limit=MAX_REQUIRED_EVIDENCE,
+        )
+        criterion_id, criterion_id_truncated = _bounded_text(criterion.id)
+        retained.append(
+            {
+                "id": criterion_id,
+                "id_truncated": criterion_id_truncated,
+                "statement": statement,
+                "statement_truncated": statement_truncated,
+                "required_evidence": evidence,
+            }
+        )
+    return {
+        "items": retained,
+        "total_items": len(criteria),
+        "returned_items": len(retained),
+        "truncated": len(retained) < len(criteria),
+    }
+
+
+def _approval_state(node: Node) -> str:
+    if node.intent is None:
+        return "missing_intent_ir"
+    return node.intent.approval.state.value
+
+
+def _is_approved(node: Node) -> bool:
+    return (
+        node.intent is not None and node.intent.approval.state == ApprovalState.APPROVED
+    )
+
+
+def _relationship_is_observable(
+    source: Node,
+    target: Node,
+    relation: EdgeType,
+) -> bool:
+    """Return whether the current Reality parser can emit this relationship shape."""
+
+    if relation == EdgeType.CONTAINS:
+        return True
+    if relation == EdgeType.DEPENDS_ON:
+        return source.type == NodeType.MODULE and target.type == NodeType.MODULE
+    return False
+
+
+def _subject_name(node: Node) -> dict[str, Any]:
+    name, truncated = _bounded_text(node.name)
+    return {
+        "type": node.type.value,
+        "name": name,
+        "name_truncated": truncated,
+    }
+
+
+class DriftTriageEngine:
+    """Classify safe reconciliation work without mutating DAG or backlog state."""
+
+    _classification_order = (
+        "missing_implementation",
+        "needs_classification",
+        "identity_review_required",
+        "framework_tooling_drift",
+        "obsolete_or_unapproved_intent",
+    )
+
+    def __init__(self, intention: DAGManager, reality: DAGManager):
+        self.intention = intention
+        self.reality = reality
+        self._intent_by_canonical_id = self._canonical_node_index(
+            intention,
+            dag_name="Intention DAG",
+        )
+
+    @staticmethod
+    def _canonical_node_index(
+        manager: DAGManager,
+        *,
+        dag_name: str,
+    ) -> dict[str, Node]:
+        index: dict[str, Node] = {}
+        for source_id, node in manager.nodes.items():
+            canonical_id = str(UUID(source_id))
+            if canonical_id in index:
+                raise ValueError(
+                    f"{dag_name} contains duplicate canonical GUID {canonical_id}"
+                )
+            index[canonical_id] = node
+        return index
+
+    @staticmethod
+    def _validate_limit(value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("max_items must be an integer")
+        if value < 1:
+            raise ValueError("max_items must be at least 1")
+
+    def source_identity(self) -> dict[str, str]:
+        intention_sha256 = _canonical_dag_sha256(self.intention)
+        reality_sha256 = _canonical_dag_sha256(self.reality)
+        plan_digest = hashlib.sha256(
+            _canonical_json(
+                {
+                    "triage_contract": TRIAGE_SCHEMA_VERSION,
+                    "intention_sha256": intention_sha256,
+                    "reality_sha256": reality_sha256,
+                }
+            )
+        ).hexdigest()
+        return {
+            "intention_sha256": intention_sha256,
+            "reality_sha256": reality_sha256,
+            "plan_digest": plan_digest,
+        }
+
+    def _full_safe_plan(self) -> dict[str, Any]:
+        maximum_tasks = max(1, len(self.intention.nodes) + len(self.intention.edges))
+        plan = DiffingEngine(
+            self.intention,
+            self.reality,
+            policy=DiffPolicy.safe(max_tasks=maximum_tasks),
+        ).calculate_diff()
+        if plan["meta"]["truncated"]:
+            raise ValueError(
+                "internal safe plan bound did not retain every triage subject"
+            )
+        return plan
+
+    @staticmethod
+    def _decision_payload(decision: TriageDecision) -> dict[str, Any]:
+        return {
+            "rationale": decision.rationale,
+            "evidence": list(decision.evidence),
+            "decided_by": decision.decided_by,
+            "decided_at": decision.decided_at.isoformat(),
+        }
+
+    def _intent_item(
+        self,
+        task: dict[str, Any],
+        decisions: dict[str, TriageDecision],
+        used_decisions: set[str],
+    ) -> dict[str, Any]:
+        source_id = task.get("canonical_intent_id") or task["evidence"].get(
+            "canonical_guid"
+        )
+        if source_id is None:
+            raise ValueError(f"safe task {task['action']} has no canonical intent ID")
+        canonical_id = str(UUID(source_id))
+        node = self._intent_by_canonical_id[canonical_id]
+        subject_key = f"intent:{canonical_id}"
+        approval_state = _approval_state(node)
+        action = task["action"]
+        decision = decisions.get(subject_key)
+
+        if action in {"review_mapping", "resolve_ambiguous_mapping"}:
+            classification = "identity_review_required"
+            reason = "Identity evidence must be resolved before implementation drift can be classified."
+            decision_source = "identity_gate"
+        elif not _is_approved(node):
+            classification = "obsolete_or_unapproved_intent"
+            reason = (
+                f"Intent approval state is {approval_state}; implementation is withheld "
+                "until the canonical intent is approved or retired."
+            )
+            decision_source = "approval_gate"
+        elif decision is None:
+            classification = "needs_classification"
+            reason = (
+                "Approved intent has no deterministic Reality match; explicit evidence is "
+                "required to distinguish missing implementation from tooling drift."
+            )
+            decision_source = "pending"
+        else:
+            classification = decision.classification.value
+            reason = decision.rationale
+            decision_source = "explicit"
+            used_decisions.add(subject_key)
+
+        subject = {"kind": "intent", **_subject_name(node)}
+        item = {
+            "subject": subject,
+            "classification": classification,
+            "reason": reason,
+            "decision_source": decision_source,
+            "implementation_authorized": classification
+            == DriftClassification.MISSING_IMPLEMENTATION.value
+            and _is_approved(node),
+            "evidence": {
+                "approval_state": approval_state,
+                "safe_action": action,
+                "acceptance_criteria": _acceptance_criteria(node),
+            },
+            "audit": {
+                "subject_key": subject_key,
+                "canonical_intent_id": canonical_id,
+            },
+        }
+        if decision_source == "explicit":
+            item["decision"] = self._decision_payload(decision)
+        return item
+
+    def _relationship_item(
+        self,
+        task: dict[str, Any],
+        decisions: dict[str, TriageDecision],
+        used_decisions: set[str],
+    ) -> dict[str, Any]:
+        relationship = task["evidence"]["relationship"]
+        source_id = str(UUID(relationship["source_id"]))
+        target_id = str(UUID(relationship["target_id"]))
+        relation = EdgeType(relationship["type"])
+        source = self._intent_by_canonical_id[source_id]
+        target = self._intent_by_canonical_id[target_id]
+        subject_key = f"relationship:{source_id}:{relation.value}:{target_id}"
+        decision = decisions.get(subject_key)
+
+        if not _is_approved(source) or not _is_approved(target):
+            classification = "obsolete_or_unapproved_intent"
+            reason = (
+                "At least one relationship endpoint is not approved; no implementation "
+                "work may be inferred from the missing observation."
+            )
+            decision_source = "approval_gate"
+        elif not _relationship_is_observable(source, target, relation):
+            classification = "framework_tooling_drift"
+            reason = (
+                f"The current Reality parser does not emit {relation.value} relationships "
+                f"for {source.type.value}-to-{target.type.value} endpoints."
+            )
+            decision_source = "observation_contract"
+        elif decision is None:
+            classification = "needs_classification"
+            reason = (
+                "The relationship is observable in principle, but absence alone does not "
+                "prove missing implementation."
+            )
+            decision_source = "pending"
+        else:
+            classification = decision.classification.value
+            reason = decision.rationale
+            decision_source = "explicit"
+            used_decisions.add(subject_key)
+
+        item = {
+            "subject": {
+                "kind": "relationship",
+                "source": _subject_name(source),
+                "relation": relation.value,
+                "target": _subject_name(target),
+            },
+            "classification": classification,
+            "reason": reason,
+            "decision_source": decision_source,
+            "implementation_authorized": classification
+            == DriftClassification.MISSING_IMPLEMENTATION.value
+            and _is_approved(source)
+            and _is_approved(target),
+            "evidence": {
+                "source_approval_state": _approval_state(source),
+                "target_approval_state": _approval_state(target),
+                "safe_action": task["action"],
+                "relationship_observable": _relationship_is_observable(
+                    source,
+                    target,
+                    relation,
+                ),
+            },
+            "audit": {
+                "subject_key": subject_key,
+                "source_intent_id": source_id,
+                "target_intent_id": target_id,
+            },
+        }
+        if decision_source == "explicit":
+            item["decision"] = self._decision_payload(decision)
+        return item
+
+    def analyze(
+        self,
+        *,
+        decisions: TriageDecisionSet | None = None,
+        max_items: int = DEFAULT_MAX_ITEMS,
+    ) -> dict[str, Any]:
+        """Return a bounded triage report with complete classification totals."""
+
+        self._validate_limit(max_items)
+        source = self.source_identity()
+        if decisions is not None and decisions.plan_digest != source["plan_digest"]:
+            raise ValueError(
+                "stale triage decisions: plan_digest does not match current DAG state"
+            )
+        decision_index = {
+            decision.subject_key: decision
+            for decision in (decisions.decisions if decisions else [])
+        }
+        used_decisions: set[str] = set()
+        plan = self._full_safe_plan()
+        summary = {
+            "plan_tasks": plan["meta"]["total_tasks"],
+            "missing_implementation": 0,
+            "obsolete_or_unapproved_intent": 0,
+            "framework_tooling_drift": 0,
+            "identity_review_required": 0,
+            "needs_classification": 0,
+            "actionable_implementation": 0,
+        }
+        retained = {classification: [] for classification in self._classification_order}
+
+        for task in plan["nodes"].values():
+            if task["action"] == "connect_confirmed":
+                item = self._relationship_item(task, decision_index, used_decisions)
+            else:
+                item = self._intent_item(task, decision_index, used_decisions)
+            classification = item["classification"]
+            summary[classification] += 1
+            if item["implementation_authorized"]:
+                summary["actionable_implementation"] += 1
+            bucket = retained[classification]
+            if len(bucket) < max_items:
+                bucket.append(item)
+
+        unused = sorted(set(decision_index).difference(used_decisions))
+        if unused:
+            raise ValueError(
+                "triage decisions reference unknown or inapplicable subjects: "
+                + ", ".join(unused)
+            )
+
+        items = []
+        for classification in self._classification_order:
+            remaining = max_items - len(items)
+            if remaining == 0:
+                break
+            items.extend(retained[classification][:remaining])
+
+        total_items = summary["plan_tasks"]
+        return {
+            "schema_version": TRIAGE_SCHEMA_VERSION,
+            "source": source,
+            "summary": summary,
+            "limit": {
+                "max_items": max_items,
+                "total_items": total_items,
+                "returned_items": len(items),
+                "truncated": len(items) < total_items,
+            },
+            "items": items,
+        }
+
+
+def _subject_label(subject: dict[str, Any]) -> str:
+    if subject["kind"] == "intent":
+        return f"{subject['type'].capitalize()} '{subject['name']}'"
+    source = subject["source"]
+    target = subject["target"]
+    return (
+        f"{source['type'].capitalize()} '{source['name']}' "
+        f"{subject['relation']} {target['type'].capitalize()} '{target['name']}'"
+    )
+
+
+def render_drift_triage(report: dict[str, Any]) -> str:
+    """Render a GUID-last human brief from a drift triage report."""
+
+    summary = report["summary"]
+    limit = report["limit"]
+    lines = [
+        "Reconciliation drift triage",
+        "",
+        f"{limit['returned_items']} of {limit['total_items']} triage items shown.",
+        f"Actionable missing implementation: {summary['actionable_implementation']}",
+        f"Needs classification: {summary['needs_classification']}",
+        f"Identity review required: {summary['identity_review_required']}",
+        f"Framework tooling drift: {summary['framework_tooling_drift']}",
+        "Obsolete or unapproved intent: " f"{summary['obsolete_or_unapproved_intent']}",
+        "",
+    ]
+    for item in report["items"]:
+        classification = item["classification"].replace("_", " ")
+        lines.extend(
+            [
+                f"- {_subject_label(item['subject'])}: {classification}",
+                f"  Reason: {item['reason']}",
+                "  Implementation authorized: "
+                + ("yes" if item["implementation_authorized"] else "no"),
+            ]
+        )
+
+    lines.extend(["", "Audit", f"Plan digest: {report['source']['plan_digest']}"])
+    for item in report["items"]:
+        lines.append(
+            f"- {_subject_label(item['subject'])}: {item['audit']['subject_key']}"
+        )
+    return "\n".join(lines)

--- a/src/aio_agentic_sdlc/drift_triage.py
+++ b/src/aio_agentic_sdlc/drift_triage.py
@@ -235,6 +235,8 @@ class DriftTriageEngine:
     )
 
     def __init__(self, intention: DAGManager, reality: DAGManager):
+        intention.validate()
+        reality.validate()
         self.intention = intention
         self.reality = reality
         self._intent_by_canonical_id = self._canonical_node_index(

--- a/src/aio_agentic_sdlc/mcp_server.py
+++ b/src/aio_agentic_sdlc/mcp_server.py
@@ -18,6 +18,7 @@ from .core import (
 )
 from .dag_manager import DAGManager
 from .dag_models import Node, NodeType
+from .drift_triage import DriftTriageEngine, TriageDecisionSet
 from .intent_ir import IntentIR
 from .intent_store import create_intent_node_file, update_intent_file
 from .mapping import MappingApproval, MappingEngine
@@ -381,6 +382,48 @@ def reconcile_dags(
         return json.dumps(report, indent=2)
     except Exception as e:
         return f"Error reconciling DAGs: {str(e)}"
+
+
+@mcp.tool()
+def triage_reconciliation_drift(
+    project_path: Annotated[
+        str, Field(description="Absolute path to the project directory")
+    ] = ".",
+    decisions_json: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional digest-bound TriageDecisionSet JSON; leave empty for "
+                "deterministic approval and observation routing"
+            )
+        ),
+    ] = "",
+    max_items: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum triage records returned; totals remain complete",
+        ),
+    ] = 100,
+) -> str:
+    """Classify safe reconciliation work before backlog execution."""
+
+    try:
+        project_root = os.path.abspath(project_path)
+        intention = DAGManager.load(os.path.join(project_root, INTENTION_DAG_FILE))
+        reality = DAGManager.load(os.path.join(project_root, REALITY_DAG_FILE))
+        decisions = (
+            TriageDecisionSet.model_validate_json(decisions_json)
+            if decisions_json.strip()
+            else None
+        )
+        report = DriftTriageEngine(intention, reality).analyze(
+            decisions=decisions,
+            max_items=max_items,
+        )
+        return json.dumps(report, indent=2)
+    except Exception as e:
+        return f"Error triaging reconciliation drift: {str(e)}"
 
 
 @mcp.tool()

--- a/tests/test_drift_triage.py
+++ b/tests/test_drift_triage.py
@@ -1,0 +1,465 @@
+import json
+from datetime import datetime, timezone
+
+import pytest
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from aio_agentic_sdlc.dag_cli import cli
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import Edge, EdgeType, Metadata, Node, NodeType
+from aio_agentic_sdlc.drift_triage import (
+    DriftTriageEngine,
+    TriageDecisionSet,
+    render_drift_triage,
+)
+from aio_agentic_sdlc.intent_ir import (
+    AcceptanceCriterion,
+    Approval,
+    ApprovalState,
+    IntentIR,
+    IntentRevision,
+    Provenance,
+    ProvenanceType,
+)
+
+
+def _intent_ir(state: ApprovalState) -> IntentIR:
+    if state == ApprovalState.APPROVED:
+        approval = Approval(
+            state=state,
+            approved_by="Felix",
+            approved_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+            rationale="Accepted for implementation.",
+        )
+    else:
+        approval = Approval(state=state)
+    return IntentIR(
+        provenance=[
+            Provenance(
+                source_type=ProvenanceType.HUMAN_STATEMENT,
+                reference="chat:triage",
+                statement="Deliver the reviewed capability.",
+            )
+        ],
+        confidence=0.9,
+        acceptance_criteria=[
+            AcceptanceCriterion(
+                id="AC-1",
+                statement="The capability is observable.",
+                required_evidence=["test:capability"],
+            )
+        ],
+        revision_history=[
+            IntentRevision(
+                revision=1,
+                recorded_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+                actor="sdlc_intake",
+                generator_version="aio-agentic-sdlc/test",
+                summary="Initial test intent.",
+            )
+        ],
+        responsible_agent="sdlc_implementer",
+        generator_version="aio-agentic-sdlc/test",
+        approval=approval,
+    )
+
+
+def _node(
+    node_id: str,
+    name: str,
+    *,
+    state: ApprovalState,
+    node_type: NodeType = NodeType.COMPONENT,
+) -> Node:
+    return Node(
+        id=node_id,
+        type=node_type,
+        name=name,
+        intent=_intent_ir(state),
+    )
+
+
+def _dag(nodes, edges=None) -> DAGManager:
+    return DAGManager(Metadata(name="Triage", version="1.0"), nodes, edges or [])
+
+
+def _decision_set(
+    engine: DriftTriageEngine, decisions: list[dict]
+) -> TriageDecisionSet:
+    return TriageDecisionSet.model_validate(
+        {
+            "schema_version": 1,
+            "plan_digest": engine.source_identity()["plan_digest"],
+            "decisions": decisions,
+        }
+    )
+
+
+def _decision(subject_key: str, classification: str) -> dict:
+    return {
+        "subject_key": subject_key,
+        "classification": classification,
+        "rationale": "Reviewed the implementation and parser evidence.",
+        "evidence": ["source:src/example.py", "test:test_example.py"],
+        "decided_by": "sdlc_cartographer",
+        "decided_at": "2026-08-15T12:00:00-04:00",
+    }
+
+
+def test_triage_withholds_unapproved_intent_from_implementation():
+    intent_id = "00000000-0000-0000-0000-000000000001"
+    engine = DriftTriageEngine(
+        _dag(
+            [
+                _node(
+                    intent_id, "Pending capability", state=ApprovalState.REVIEW_REQUIRED
+                )
+            ]
+        ),
+        _dag([]),
+    )
+
+    report = engine.analyze()
+
+    assert report["summary"] == {
+        "plan_tasks": 1,
+        "missing_implementation": 0,
+        "obsolete_or_unapproved_intent": 1,
+        "framework_tooling_drift": 0,
+        "identity_review_required": 0,
+        "needs_classification": 0,
+        "actionable_implementation": 0,
+    }
+    item = report["items"][0]
+    assert item["subject"] == {
+        "kind": "intent",
+        "type": "component",
+        "name": "Pending capability",
+        "name_truncated": False,
+    }
+    assert item["classification"] == "obsolete_or_unapproved_intent"
+    assert item["decision_source"] == "approval_gate"
+    assert item["implementation_authorized"] is False
+    assert item["evidence"]["approval_state"] == "review_required"
+
+    decisions = _decision_set(
+        engine,
+        [_decision(f"intent:{intent_id}", "missing_implementation")],
+    )
+    with pytest.raises(ValueError, match="unknown or inapplicable"):
+        engine.analyze(decisions=decisions)
+
+
+def test_approved_unmapped_intent_requires_digest_bound_decision():
+    intent_id = "00000000-0000-0000-0000-000000000002"
+    engine = DriftTriageEngine(
+        _dag([_node(intent_id, "Missing capability", state=ApprovalState.APPROVED)]),
+        _dag([]),
+    )
+
+    pending = engine.analyze()
+    assert pending["items"][0]["classification"] == "needs_classification"
+    assert pending["items"][0]["implementation_authorized"] is False
+
+    decisions = _decision_set(
+        engine,
+        [_decision(f"intent:{intent_id}", "missing_implementation")],
+    )
+    report = engine.analyze(decisions=decisions)
+
+    assert report["summary"]["missing_implementation"] == 1
+    assert report["summary"]["actionable_implementation"] == 1
+    item = report["items"][0]
+    assert item["classification"] == "missing_implementation"
+    assert item["decision_source"] == "explicit"
+    assert item["implementation_authorized"] is True
+    assert item["evidence"]["acceptance_criteria"]["items"] == [
+        {
+            "id": "AC-1",
+            "id_truncated": False,
+            "statement": "The capability is observable.",
+            "statement_truncated": False,
+            "required_evidence": {
+                "items": [{"value": "test:capability", "value_truncated": False}],
+                "total_items": 1,
+                "returned_items": 1,
+                "truncated": False,
+            },
+        }
+    ]
+
+
+def test_triage_rejects_stale_duplicate_and_unused_decisions():
+    intent_id = "00000000-0000-0000-0000-000000000003"
+    engine = DriftTriageEngine(
+        _dag([_node(intent_id, "Missing", state=ApprovalState.APPROVED)]),
+        _dag([]),
+    )
+    decision = _decision(f"intent:{intent_id}", "missing_implementation")
+
+    with pytest.raises(ValidationError, match="duplicate subject_key"):
+        _decision_set(engine, [decision, decision])
+
+    stale = _decision_set(engine, [decision]).model_copy(
+        update={"plan_digest": "0" * 64}
+    )
+    with pytest.raises(ValueError, match="stale triage decisions"):
+        engine.analyze(decisions=stale)
+
+    unknown = _decision_set(
+        engine,
+        [
+            _decision(
+                "intent:00000000-0000-0000-0000-000000000099", "missing_implementation"
+            )
+        ],
+    )
+    with pytest.raises(ValueError, match="unknown or inapplicable"):
+        engine.analyze(decisions=unknown)
+
+
+def test_triage_routes_relationships_by_approval_and_observability():
+    first_id = "00000000-0000-0000-0000-000000000011"
+    second_id = "00000000-0000-0000-0000-000000000012"
+    third_id = "00000000-0000-0000-0000-000000000013"
+    intention = _dag(
+        [
+            _node(first_id, "Approved caller", state=ApprovalState.APPROVED),
+            _node(second_id, "Approved target", state=ApprovalState.APPROVED),
+            _node(third_id, "Pending target", state=ApprovalState.REVIEW_REQUIRED),
+        ],
+        [
+            Edge(source=first_id, target=second_id, type=EdgeType.CALLS),
+            Edge(source=first_id, target=third_id, type=EdgeType.CONTAINS),
+        ],
+    )
+    reality = _dag(
+        [
+            Node(id=first_id, type=NodeType.COMPONENT, name="Approved caller"),
+            Node(id=second_id, type=NodeType.COMPONENT, name="Approved target"),
+            Node(id=third_id, type=NodeType.COMPONENT, name="Pending target"),
+        ]
+    )
+
+    report = DriftTriageEngine(intention, reality).analyze()
+    relationships = {
+        item["subject"]["relation"]: item
+        for item in report["items"]
+        if item["subject"]["kind"] == "relationship"
+    }
+
+    assert relationships["calls"]["classification"] == "framework_tooling_drift"
+    assert relationships["calls"]["decision_source"] == "observation_contract"
+    assert (
+        relationships["contains"]["classification"] == "obsolete_or_unapproved_intent"
+    )
+    assert relationships["contains"]["decision_source"] == "approval_gate"
+    assert report["summary"]["actionable_implementation"] == 0
+
+
+def test_triage_is_deterministic_bounded_and_human_readable():
+    nodes = [
+        _node(
+            f"00000000-0000-0000-0000-00000000002{index}",
+            f"Pending {index}",
+            state=ApprovalState.REVIEW_REQUIRED,
+        )
+        for index in range(3)
+    ]
+    engine = DriftTriageEngine(_dag(nodes), _dag([]))
+
+    first = engine.analyze(max_items=1)
+    second = engine.analyze(max_items=1)
+
+    assert first == second
+    assert first["limit"] == {
+        "max_items": 1,
+        "total_items": 3,
+        "returned_items": 1,
+        "truncated": True,
+    }
+    brief = render_drift_triage(first)
+    assert "1 of 3 triage items shown" in brief
+    assert "Pending 0" in brief
+    assert "Audit" in brief
+    assert brief.index("Pending 0") < brief.index(
+        "00000000-0000-0000-0000-000000000020"
+    )
+
+
+def test_triage_source_identity_is_canonical_across_order_and_guid_case():
+    first_id = "abcdefab-cdef-abcd-efab-cdefabcdef01"
+    second_id = "abcdefab-cdef-abcd-efab-cdefabcdef02"
+    first_node = _node(first_id, "First", state=ApprovalState.APPROVED)
+    second_node = _node(second_id, "Second", state=ApprovalState.APPROVED)
+    first = _dag(
+        [first_node, second_node],
+        [Edge(source=first_id, target=second_id, type=EdgeType.CONTAINS)],
+    )
+    second = _dag(
+        [
+            second_node.model_copy(update={"id": second_id.upper()}),
+            first_node.model_copy(update={"id": first_id.upper()}),
+        ],
+        [
+            Edge(
+                source=first_id.upper(),
+                target=second_id.upper(),
+                type=EdgeType.CONTAINS,
+            )
+        ],
+    )
+
+    first_source = DriftTriageEngine(first, _dag([])).source_identity()
+    second_source = DriftTriageEngine(second, _dag([])).source_identity()
+
+    assert first_source == second_source
+
+
+def test_triage_bounds_nested_acceptance_evidence_and_reports_truncation():
+    intent_id = "00000000-0000-0000-0000-000000000025"
+    criteria = [
+        AcceptanceCriterion(
+            id=f"AC-{index}-" + ("i" * 600),
+            statement="s" * 600,
+            required_evidence=[f"evidence-{item}-" + ("e" * 600) for item in range(12)],
+        )
+        for index in range(12)
+    ]
+    intent = _intent_ir(ApprovalState.APPROVED).model_copy(
+        update={"acceptance_criteria": criteria}
+    )
+    node = Node(
+        id=intent_id,
+        type=NodeType.COMPONENT,
+        name="Bounded capability",
+        intent=intent,
+    )
+
+    report = DriftTriageEngine(_dag([node]), _dag([])).analyze()
+
+    bounded = report["items"][0]["evidence"]["acceptance_criteria"]
+    assert bounded["total_items"] == 12
+    assert bounded["returned_items"] == 10
+    assert bounded["truncated"] is True
+    first = bounded["items"][0]
+    assert len(first["id"]) == 500
+    assert first["id_truncated"] is True
+    assert len(first["statement"]) == 500
+    assert first["statement_truncated"] is True
+    required = first["required_evidence"]
+    assert required["total_items"] == 12
+    assert required["returned_items"] == 10
+    assert required["truncated"] is True
+    assert len(required["items"][0]["value"]) == 500
+    assert required["items"][0]["value_truncated"] is True
+
+
+def test_cli_triage_writes_reproducible_report_without_mutating_dags(tmp_path):
+    intent_id = "00000000-0000-0000-0000-000000000031"
+    intention_path = tmp_path / "intention.yaml"
+    reality_path = tmp_path / "reality.yaml"
+    decisions_path = tmp_path / "decisions.json"
+    report_path = tmp_path / "triage.json"
+    intention = _dag(
+        [_node(intent_id, "Missing capability", state=ApprovalState.APPROVED)]
+    )
+    reality = _dag([])
+    intention.save(str(intention_path))
+    reality.save(str(reality_path))
+    engine = DriftTriageEngine(intention, reality)
+    decisions_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "plan_digest": engine.source_identity()["plan_digest"],
+                "decisions": [
+                    _decision(f"intent:{intent_id}", "missing_implementation")
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    before_intention = intention_path.read_bytes()
+    before_reality = reality_path.read_bytes()
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "triage",
+            "--intention",
+            str(intention_path),
+            "--reality",
+            str(reality_path),
+            "--decisions",
+            str(decisions_path),
+            "--format",
+            "json",
+            "--output",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        json.loads(report_path.read_text(encoding="utf-8"))["summary"][
+            "actionable_implementation"
+        ]
+        == 1
+    )
+    assert intention_path.read_bytes() == before_intention
+    assert reality_path.read_bytes() == before_reality
+
+    before_decisions = decisions_path.read_bytes()
+    rejected = CliRunner().invoke(
+        cli,
+        [
+            "triage",
+            "--intention",
+            str(intention_path),
+            "--reality",
+            str(reality_path),
+            "--decisions",
+            str(decisions_path),
+            "--output",
+            str(decisions_path),
+        ],
+    )
+    assert rejected.exit_code == 1
+    assert "protected framework state" in rejected.output
+    assert decisions_path.read_bytes() == before_decisions
+
+
+@pytest.mark.parametrize("protected", ["intention", "reality"])
+def test_cli_triage_refuses_protected_report_output(tmp_path, protected):
+    intent_id = "00000000-0000-0000-0000-000000000041"
+    intention_path = tmp_path / "intention.yaml"
+    reality_path = tmp_path / "reality.yaml"
+    _dag([_node(intent_id, "Pending", state=ApprovalState.REVIEW_REQUIRED)]).save(
+        str(intention_path)
+    )
+    _dag([]).save(str(reality_path))
+    output = intention_path if protected == "intention" else reality_path
+    before_intention = intention_path.read_bytes()
+    before_reality = reality_path.read_bytes()
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "triage",
+            "--intention",
+            str(intention_path),
+            "--reality",
+            str(reality_path),
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "protected framework state" in result.output
+    assert intention_path.read_bytes() == before_intention
+    assert reality_path.read_bytes() == before_reality

--- a/tests/test_drift_triage.py
+++ b/tests/test_drift_triage.py
@@ -107,6 +107,70 @@ def _decision(subject_key: str, classification: str) -> dict:
     }
 
 
+@pytest.mark.parametrize(
+    ("edges", "error"),
+    [
+        (
+            [
+                Edge(
+                    source="00000000-0000-0000-0000-000000000001",
+                    target="00000000-0000-0000-0000-000000000099",
+                    type=EdgeType.CONTAINS,
+                )
+            ],
+            "target node .* does not exist",
+        ),
+        (
+            [
+                Edge(
+                    source="00000000-0000-0000-0000-000000000001",
+                    target="00000000-0000-0000-0000-000000000002",
+                    type=EdgeType.DEPENDS_ON,
+                ),
+                Edge(
+                    source="00000000-0000-0000-0000-000000000002",
+                    target="00000000-0000-0000-0000-000000000001",
+                    type=EdgeType.DEPENDS_ON,
+                ),
+            ],
+            "Cycle detected",
+        ),
+    ],
+)
+def test_triage_rejects_invalid_dag_structure(edges, error):
+    nodes = [
+        _node(
+            "00000000-0000-0000-0000-000000000001",
+            "First",
+            state=ApprovalState.APPROVED,
+        ),
+        _node(
+            "00000000-0000-0000-0000-000000000002",
+            "Second",
+            state=ApprovalState.APPROVED,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match=error):
+        DriftTriageEngine(_dag(nodes, edges), _dag([]))
+
+
+def test_triage_rejects_invalid_reality_dag_structure():
+    invalid_reality = _dag(
+        [],
+        [
+            Edge(
+                source="00000000-0000-0000-0000-000000000090",
+                target="00000000-0000-0000-0000-000000000091",
+                type=EdgeType.CONTAINS,
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="source node .* does not exist"):
+        DriftTriageEngine(_dag([]), invalid_reality)
+
+
 def test_triage_withholds_unapproved_intent_from_implementation():
     intent_id = "00000000-0000-0000-0000-000000000001"
     engine = DriftTriageEngine(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,7 @@ from aio_agentic_sdlc.mcp_server import (
     generate_document,
     reconcile_dags,
     review_mapping,
+    triage_reconciliation_drift,
 )
 from aio_agentic_sdlc.workspace import (
     CHANGES_DIR,
@@ -117,6 +118,25 @@ def test_mcp_reconcile_dags_returns_the_same_evidence_report(tmp_path):
             "value": "00000000-0000-0000-0000-000000000001",
         }
     ]
+
+
+def test_mcp_triage_reconciliation_drift_withholds_unapproved_intent(tmp_path):
+    node = Node(
+        id="00000000-0000-0000-0000-000000000002",
+        type=NodeType.COMPONENT,
+        name="Unapproved capability",
+    )
+    metadata = Metadata(name="Test", version="1.0")
+    (tmp_path / INTENTION_DAG_FILE).parent.mkdir(parents=True)
+    DAGManager(metadata, [node], []).save(str(tmp_path / INTENTION_DAG_FILE))
+    DAGManager(metadata, [], []).save(str(tmp_path / REALITY_DAG_FILE))
+
+    result = json.loads(triage_reconciliation_drift(project_path=str(tmp_path)))
+
+    assert result["schema_version"] == 1
+    assert result["summary"]["obsolete_or_unapproved_intent"] == 1
+    assert result["summary"]["actionable_implementation"] == 0
+    assert result["items"][0]["decision_source"] == "approval_gate"
 
 
 def test_mcp_mapping_review_and_approval_use_source_bound_evidence(tmp_path):


### PR DESCRIPTION
## Summary
- add a read-only, approval-aware drift triage layer between safe reconciliation and backlog execution
- bind explicit classifications to canonical Intention and Reality content with a reproducible plan digest
- expose name-first/GUID-last human CLI output plus JSON CLI and MCP parity
- update the Codex plugin workflow so only approved, explicitly classified missing implementation reaches an implementer

## Dogfood outcome
The exact current 55-item safe plan now resolves to:
- 1 missing implementation, authorized: `DAG Visualization and Comparison`
- 52 obsolete or unapproved intent/relationships, withheld from implementation
- 2 framework-tooling drift items
- 0 identity-review or unresolved classification items

The single authorized visualization task was added to the local framework backlog. The backlog remains local/ignored; the digest-bound decisions and complete derived report are versioned under `.aio-agentic-sdlc/changes/drift-triage/`.

## Safety
- non-approved intent can never authorize implementation
- stale, duplicate, unused, and inapplicable decisions fail closed
- canonical DAG hashes are independent of YAML order, GUID casing, and checkout line endings
- top-level output and nested acceptance evidence are bounded with complete totals/truncation metadata
- report output rejects canonical DAGs, protected state, and the decision input itself
- triage never mutates either DAG or the backlog

## Validation
- `uv run --no-sync pytest -W error -q` — 285 passed
- focused reconciliation/CLI/MCP suite — 54 passed
- Ruff and Black — passed
- `uv lock --check` and `uv build` — passed
- strict Intention IR and Reality DAG validation — passed
- manage-sdlc skill and Codex plugin validators — passed
- Markdownlint — 0 issues
- generated Reality reproduced byte-for-byte — `9D73D1ED1DDF23A991DB04DB6E804F15A0CCB640C9793A70E27A7013038508AF`
- generated triage report reproduced byte-for-byte — `3AF3A2D1448DF704879F616D3D28BA3E653AECB32843DE3C78C8D3D5B3D4FA0F`
- built wheel contains `aio_agentic_sdlc/drift_triage.py`