### PR TITLE
feat(dag): add visualization and comparison

### DIFF
--- a/.aio-agentic-sdlc/changes/dag-visualization-comparison/sdd.md
+++ b/.aio-agentic-sdlc/changes/dag-visualization-comparison/sdd.md
@@ -1,0 +1,41 @@
+---
+document_type: sdd
+title: "DAG Visualization and Comparison"
+author: "sdlc_architect"
+date: "2026-08-17"
+related_prd: "intention:841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58"
+node_id: "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58"
+
+---
+# DAG Visualization and Comparison
+
+## 1. Architecture Overview
+
+Add one read-only DAGVisualizationEngine that validates canonical DAG inputs, delegates identity classification to ReconciliationEngine, and produces one deterministic bounded report. Pure human and Mermaid renderers consume that report; CLI and MCP adapters contain no traversal or matching logic. No runtime Mermaid dependency is added.
+
+## 2. System Components
+
+- DAGVisualizationEngine: Intention, Reality, focused-neighborhood, and comparison report construction.
+- ReconciliationEngine: authoritative confirmed, candidate, ambiguous, and unmapped classification.
+- render_dag_human / render_dag_mermaid: safe name-first presentation.
+- dag-tool visualize and visualize_dag MCP: equivalent adapters over canonical local workspace state.
+- manage-sdlc Cartographer guidance: present visual evidence before identity approval.
+
+## 3. Data Model
+
+Schema version 1 includes view, focus/depth, complete summary totals, record/edge/candidate limits, bounded records, intended and observed relationships, reconciliation classification, explicit evidence state, and optional exact SourceLocation evidence. Selection is deterministic by distance then canonical GUID; edge order is canonical source, target, type, description.
+
+## 4. API Design
+
+- CLI: `dag-tool visualize --project-path PATH --view intention|reality|comparison` with optional focus, depth, item, edge, candidate, and format bounds.
+- MCP: `visualize_dag` exposes the same view, focus, depth, bounds, and output format.
+- Both adapters reject invalid limits, invalid DAGs, unknown focus nodes, and unsupported formats.
+
+## 5. Security Considerations
+
+- Never mutate DAG, backlog, audit, source, or lock state.
+- Validate canonicalized DAG identities and relationships before traversal.
+- Bound node, edge, candidate, nested-source, and text output while retaining complete totals and truncation metadata.
+- Mermaid uses fixed synthetic identifiers and quoted, entity-escaped bounded labels. It emits no links, click directives, raw HTML, frontmatter, or user-provided directives.
+- Missing or stale source provenance is reported unavailable and never inferred.
+- Test references do not establish behavioral verification.

--- a/.aio-agentic-sdlc/changes/dag-visualization-comparison/self-dogfood-report.json
+++ b/.aio-agentic-sdlc/changes/dag-visualization-comparison/self-dogfood-report.json
@@ -1,0 +1,478 @@
+{
+  "schema_version": 1,
+  "view": "comparison",
+  "focus": {
+    "node_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+    "depth": 1
+  },
+  "source_discovery": {
+    "state": "available",
+    "reason": "Fresh generated Reality exactly matches the loaded canonical Reality DAG."
+  },
+  "summary": {
+    "available_intention_nodes": 59,
+    "available_reality_nodes": 642,
+    "selected_intention_nodes": 3,
+    "selected_reality_nodes": 6,
+    "classifications": {
+      "confirmed": 2,
+      "candidate": 0,
+      "ambiguous": 0,
+      "unmapped": 1
+    },
+    "intended_relationships": 2,
+    "observed_relationships": 5
+  },
+  "limits": {
+    "records": {
+      "max_items": 20,
+      "total_items": 8,
+      "returned_items": 8,
+      "truncated": false
+    },
+    "intended_relationships": {
+      "max_edges": 20,
+      "total_edges": 2,
+      "returned_edges": 2,
+      "truncated": false
+    },
+    "observed_relationships": {
+      "max_edges": 20,
+      "total_edges": 5,
+      "returned_edges": 5,
+      "truncated": false
+    }
+  },
+  "records": [
+    {
+      "canonical_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "subject_kind": "intent",
+      "distance": 0,
+      "classification": "confirmed",
+      "intention": {
+        "id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+        "type": "component",
+        "name": "DAG Visualization and Comparison",
+        "name_truncated": false,
+        "domain": "ux",
+        "domain_truncated": false,
+        "description": "Renders bounded human-readable I-DAG and R-DAG views with reconciliation and source evidence.",
+        "description_truncated": false
+      },
+      "reality_candidates": [
+        {
+          "id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+          "type": "module",
+          "name": "dag_visualization.py",
+          "name_truncated": false,
+          "description": "Module 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+          "description_truncated": false,
+          "source_evidence": {
+            "state": "available",
+            "locations": [
+              {
+                "path": "src/aio_agentic_sdlc/dag_visualization.py",
+                "symbol_kind": "module",
+                "symbol_name": "dag_visualization.py",
+                "definition_line": 1,
+                "marker_line": 1,
+                "source_sha256": "cfac39199d468c22250f35e03b53c9cb40fd49ce1d32c4132e23eafdaf12b173"
+              }
+            ],
+            "location_truncation": [
+              {
+                "path": false,
+                "symbol_kind": false,
+                "symbol_name": false,
+                "source_sha256": false
+              }
+            ],
+            "limit": {
+              "max_items": 5,
+              "total_items": 1,
+              "returned_items": 1,
+              "truncated": false
+            }
+          }
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 5,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
+      "identity_evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58"
+        }
+      ],
+      "requires_approval": false,
+      "evidence_state": {
+        "identity": "available",
+        "source": "available",
+        "behavioral_verification": "unavailable"
+      }
+    },
+    {
+      "canonical_id": "6ac347d4-f1d9-57ca-b4b1-285ad583fead",
+      "subject_kind": "reality",
+      "distance": 1,
+      "reality": {
+        "id": "6ac347d4-f1d9-57ca-b4b1-285ad583fead",
+        "type": "component",
+        "name": "render_dag_human",
+        "name_truncated": false,
+        "description": "Render a concise name-first report without exposing DAG serialization.",
+        "description_truncated": false
+      },
+      "source_evidence": {
+        "state": "available",
+        "locations": [
+          {
+            "path": "src/aio_agentic_sdlc/dag_visualization.py",
+            "symbol_kind": "function",
+            "symbol_name": "render_dag_human",
+            "definition_line": 843,
+            "marker_line": 843,
+            "source_sha256": "cfac39199d468c22250f35e03b53c9cb40fd49ce1d32c4132e23eafdaf12b173"
+          }
+        ],
+        "location_truncation": [
+          {
+            "path": false,
+            "symbol_kind": false,
+            "symbol_name": false,
+            "source_sha256": false
+          }
+        ],
+        "limit": {
+          "max_items": 5,
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "evidence_state": {
+        "identity": "unavailable",
+        "source": "available",
+        "behavioral_verification": "unavailable"
+      },
+      "classification": "unclassified_reality"
+    },
+    {
+      "canonical_id": "719b92f7-5e13-5bca-9990-75f7b431ec3b",
+      "subject_kind": "reality",
+      "distance": 1,
+      "reality": {
+        "id": "719b92f7-5e13-5bca-9990-75f7b431ec3b",
+        "type": "system",
+        "name": "system_root",
+        "name_truncated": false,
+        "description": "Root project system",
+        "description_truncated": false
+      },
+      "source_evidence": {
+        "state": "unavailable",
+        "locations": [],
+        "location_truncation": [],
+        "limit": {
+          "max_items": 5,
+          "total_items": 0,
+          "returned_items": 0,
+          "truncated": false
+        },
+        "reason": "No exact SourceLocation evidence was supplied."
+      },
+      "evidence_state": {
+        "identity": "unavailable",
+        "source": "unavailable",
+        "behavioral_verification": "unavailable"
+      },
+      "classification": "unclassified_reality"
+    },
+    {
+      "canonical_id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+      "subject_kind": "intent",
+      "distance": 1,
+      "classification": "confirmed",
+      "intention": {
+        "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+        "type": "component",
+        "name": "Evidence-Gated Reconciliation Baseline",
+        "name_truncated": false,
+        "domain": "verification",
+        "domain_truncated": false,
+        "description": "Deterministic, non-destructive bridge from canonical intent to observed repository reality.",
+        "description_truncated": false
+      },
+      "reality_candidates": [
+        {
+          "id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+          "type": "module",
+          "name": "reconciliation.py",
+          "name_truncated": false,
+          "description": "Module 9015c8a3-fd14-5598-916d-d03fcf41e415",
+          "description_truncated": false,
+          "source_evidence": {
+            "state": "available",
+            "locations": [
+              {
+                "path": "src/aio_agentic_sdlc/reconciliation.py",
+                "symbol_kind": "module",
+                "symbol_name": "reconciliation.py",
+                "definition_line": 1,
+                "marker_line": 1,
+                "source_sha256": "a81e6098b0220d0ce67ca86b11f3be3bf18f7e776586e7d199d9c268f093cd72"
+              }
+            ],
+            "location_truncation": [
+              {
+                "path": false,
+                "symbol_kind": false,
+                "symbol_name": false,
+                "source_sha256": false
+              }
+            ],
+            "limit": {
+              "max_items": 5,
+              "total_items": 1,
+              "returned_items": 1,
+              "truncated": false
+            }
+          }
+        }
+      ],
+      "candidate_limit": {
+        "max_candidates": 5,
+        "total_candidates": 1,
+        "returned_candidates": 1,
+        "truncated": false
+      },
+      "identity_evidence": [
+        {
+          "kind": "canonical_guid",
+          "value": "9015c8a3-fd14-5598-916d-d03fcf41e415"
+        }
+      ],
+      "requires_approval": false,
+      "evidence_state": {
+        "identity": "available",
+        "source": "available",
+        "behavioral_verification": "unavailable"
+      }
+    },
+    {
+      "canonical_id": "a630d02a-ba78-57bf-a37b-cd2a8a7b5e90",
+      "subject_kind": "reality",
+      "distance": 1,
+      "reality": {
+        "id": "a630d02a-ba78-57bf-a37b-cd2a8a7b5e90",
+        "type": "component",
+        "name": "render_dag_mermaid",
+        "name_truncated": false,
+        "description": "Render a report as safe Mermaid using only synthetic identifiers.",
+        "description_truncated": false
+      },
+      "source_evidence": {
+        "state": "available",
+        "locations": [
+          {
+            "path": "src/aio_agentic_sdlc/dag_visualization.py",
+            "symbol_kind": "function",
+            "symbol_name": "render_dag_mermaid",
+            "definition_line": 795,
+            "marker_line": 795,
+            "source_sha256": "cfac39199d468c22250f35e03b53c9cb40fd49ce1d32c4132e23eafdaf12b173"
+          }
+        ],
+        "location_truncation": [
+          {
+            "path": false,
+            "symbol_kind": false,
+            "symbol_name": false,
+            "source_sha256": false
+          }
+        ],
+        "limit": {
+          "max_items": 5,
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "evidence_state": {
+        "identity": "unavailable",
+        "source": "available",
+        "behavioral_verification": "unavailable"
+      },
+      "classification": "unclassified_reality"
+    },
+    {
+      "canonical_id": "a8572269-49b7-58b6-874e-1cbe5cbe0290",
+      "subject_kind": "reality",
+      "distance": 1,
+      "reality": {
+        "id": "a8572269-49b7-58b6-874e-1cbe5cbe0290",
+        "type": "component",
+        "name": "render_dag",
+        "name_truncated": false,
+        "description": "Render one report through the shared CLI/MCP format contract.",
+        "description_truncated": false
+      },
+      "source_evidence": {
+        "state": "available",
+        "locations": [
+          {
+            "path": "src/aio_agentic_sdlc/dag_visualization.py",
+            "symbol_kind": "function",
+            "symbol_name": "render_dag",
+            "definition_line": 951,
+            "marker_line": 951,
+            "source_sha256": "cfac39199d468c22250f35e03b53c9cb40fd49ce1d32c4132e23eafdaf12b173"
+          }
+        ],
+        "location_truncation": [
+          {
+            "path": false,
+            "symbol_kind": false,
+            "symbol_name": false,
+            "source_sha256": false
+          }
+        ],
+        "limit": {
+          "max_items": 5,
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "evidence_state": {
+        "identity": "unavailable",
+        "source": "available",
+        "behavioral_verification": "unavailable"
+      },
+      "classification": "unclassified_reality"
+    },
+    {
+      "canonical_id": "bd4d54d7-1bf2-5246-b5a3-261a9c28f36d",
+      "subject_kind": "reality",
+      "distance": 1,
+      "reality": {
+        "id": "bd4d54d7-1bf2-5246-b5a3-261a9c28f36d",
+        "type": "component",
+        "name": "DAGVisualizationEngine",
+        "name_truncated": false,
+        "description": "Build one bounded report from validated canonical DAG snapshots.",
+        "description_truncated": false
+      },
+      "source_evidence": {
+        "state": "available",
+        "locations": [
+          {
+            "path": "src/aio_agentic_sdlc/dag_visualization.py",
+            "symbol_kind": "class",
+            "symbol_name": "DAGVisualizationEngine",
+            "definition_line": 169,
+            "marker_line": 169,
+            "source_sha256": "cfac39199d468c22250f35e03b53c9cb40fd49ce1d32c4132e23eafdaf12b173"
+          }
+        ],
+        "location_truncation": [
+          {
+            "path": false,
+            "symbol_kind": false,
+            "symbol_name": false,
+            "source_sha256": false
+          }
+        ],
+        "limit": {
+          "max_items": 5,
+          "total_items": 1,
+          "returned_items": 1,
+          "truncated": false
+        }
+      },
+      "evidence_state": {
+        "identity": "unavailable",
+        "source": "available",
+        "behavioral_verification": "unavailable"
+      },
+      "classification": "unclassified_reality"
+    },
+    {
+      "canonical_id": "f4658dd7-1ea1-5e1f-b851-2a376cc1649a",
+      "subject_kind": "intent",
+      "distance": 1,
+      "classification": "unmapped",
+      "intention": {
+        "id": "f4658dd7-1ea1-5e1f-b851-2a376cc1649a",
+        "type": "component",
+        "name": "Legacy Intent IR Migration",
+        "name_truncated": false,
+        "domain": "governance",
+        "domain_truncated": false,
+        "description": "Compiles legacy Intention nodes into provenance-preserving, reviewable Intent IR without manual YAML maintenance.",
+        "description_truncated": false
+      },
+      "reality_candidates": [],
+      "candidate_limit": {
+        "max_candidates": 5,
+        "total_candidates": 0,
+        "returned_candidates": 0,
+        "truncated": false
+      },
+      "identity_evidence": [],
+      "requires_approval": true,
+      "evidence_state": {
+        "identity": "unavailable",
+        "source": "unavailable",
+        "behavioral_verification": "unavailable"
+      }
+    }
+  ],
+  "intended_relationships": [
+    {
+      "source_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "target_id": "9015c8a3-fd14-5598-916d-d03fcf41e415",
+      "type": "depends_on",
+      "description": "Comparison view consumes evidence-gated reconciliation classifications.",
+      "description_truncated": false
+    },
+    {
+      "source_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "target_id": "f4658dd7-1ea1-5e1f-b851-2a376cc1649a",
+      "type": "depends_on",
+      "description": "Comparison requires reviewable intent rather than legacy labels alone.",
+      "description_truncated": false
+    }
+  ],
+  "observed_relationships": [
+    {
+      "source_id": "719b92f7-5e13-5bca-9990-75f7b431ec3b",
+      "target_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "type": "contains"
+    },
+    {
+      "source_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "target_id": "6ac347d4-f1d9-57ca-b4b1-285ad583fead",
+      "type": "contains"
+    },
+    {
+      "source_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "target_id": "a630d02a-ba78-57bf-a37b-cd2a8a7b5e90",
+      "type": "contains"
+    },
+    {
+      "source_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "target_id": "a8572269-49b7-58b6-874e-1cbe5cbe0290",
+      "type": "contains"
+    },
+    {
+      "source_id": "841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58",
+      "target_id": "bd4d54d7-1bf2-5246-b5a3-261a9c28f36d",
+      "type": "contains"
+    }
+  ]
+}

--- a/.aio-agentic-sdlc/reality-dag.yaml
+++ b/.aio-agentic-sdlc/reality-dag.yaml
@@ -303,6 +303,10 @@ nodes:
   type: component
   name: reconcile
   description: Render a bounded, read-only reconciliation evidence report.
+- id: 3e8a1ea7-2960-5b5d-ab75-4b455163995e
+  type: component
+  name: visualize
+  description: Render canonical DAGs without mutating project or framework state.
 - id: 65e8c64a-7f28-515f-b34b-d6afa699f8ee
   type: component
   name: triage
@@ -457,6 +461,39 @@ nodes:
   name: mutate_dag_file
   description: Load, mutate, validate through the callback, and atomically save under
     one lock.
+- id: 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58
+  type: module
+  name: dag_visualization.py
+  description: Module 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58
+- id: bd4d54d7-1bf2-5246-b5a3-261a9c28f36d
+  type: component
+  name: DAGVisualizationEngine
+  description: Build one bounded report from validated canonical DAG snapshots.
+- id: 8957d2e8-8aba-511d-834e-d4682f0da437
+  type: component
+  name: __init__
+  description: Function __init__
+- id: 36bd5a9b-b93f-5bdb-9c64-9a6da1d6ebfa
+  type: component
+  name: from_project
+  description: Load canonical state and admit fresh source locations only on exact
+    match.
+- id: 9a39b100-47db-5b5d-bc8f-5b40600c828f
+  type: component
+  name: build_report
+  description: Build one deterministic bounded view without mutating either DAG.
+- id: a630d02a-ba78-57bf-a37b-cd2a8a7b5e90
+  type: component
+  name: render_dag_mermaid
+  description: Render a report as safe Mermaid using only synthetic identifiers.
+- id: 6ac347d4-f1d9-57ca-b4b1-285ad583fead
+  type: component
+  name: render_dag_human
+  description: Render a concise name-first report without exposing DAG serialization.
+- id: a8572269-49b7-58b6-874e-1cbe5cbe0290
+  type: component
+  name: render_dag
+  description: Render one report through the shared CLI/MCP format contract.
 - id: c3695b6b-abf2-537d-9ed0-0f9df0dfc354
   type: module
   name: detect.py
@@ -751,6 +788,10 @@ nodes:
   name: reconcile_dags
   description: Classify Intention/Reality identity evidence without mutating project
     state.
+- id: 6c1688ad-cc50-56c2-ac2a-946c11b807d1
+  type: component
+  name: visualize_dag
+  description: Render canonical DAG evidence without mutating project state.
 - id: 264ef644-878c-502b-b4a7-d1a47bb29205
   type: component
   name: triage_reconciliation_drift
@@ -1269,6 +1310,10 @@ nodes:
   type: component
   name: test_codex_skill_routes_intent_ir_through_protected_tools
   description: Function test_codex_skill_routes_intent_ir_through_protected_tools
+- id: 5c295d8e-7164-5afe-b042-f228de5e5c93
+  type: component
+  name: test_codex_skill_routes_visual_review_before_mapping_approval
+  description: Function test_codex_skill_routes_visual_review_before_mapping_approval
 - id: 1c07436a-39e8-55f5-a363-5262b6c373cb
   type: component
   name: test_project_scoped_codex_agents_map_every_sdlc_role
@@ -1285,6 +1330,10 @@ nodes:
   type: component
   name: test_cli_validate
   description: Function test_cli_validate
+- id: b033d30f-2bcf-52df-9b9d-9bb377b0be24
+  type: component
+  name: test_cli_validate_rejects_duplicate_raw_node_ids
+  description: Function test_cli_validate_rejects_duplicate_raw_node_ids
 - id: e639c56f-f276-5fc7-890c-49797276985a
   type: component
   name: test_cli_node_add
@@ -1313,6 +1362,14 @@ nodes:
   type: component
   name: test_cli_reconcile_returns_bounded_read_only_report
   description: Function test_cli_reconcile_returns_bounded_read_only_report
+- id: d052f200-2690-5b29-8071-88f5473c8c8d
+  type: component
+  name: test_cli_visualize_supports_all_formats_and_never_mutates_state
+  description: Function test_cli_visualize_supports_all_formats_and_never_mutates_state
+- id: 57052f55-f22b-5a49-a22e-2ab271f6e666
+  type: component
+  name: test_cli_visualize_rejects_unknown_focus_and_invalid_limits
+  description: Function test_cli_visualize_rejects_unknown_focus_and_invalid_limits
 - id: e7f83e89-dfc0-5c43-bf0e-23533fe2d987
   type: component
   name: test_cli_reconcile_can_write_a_reproducible_report_artifact
@@ -1397,6 +1454,54 @@ nodes:
   type: component
   name: test_reality_generation_rejects_leaf_swap_without_external_write
   description: Function test_reality_generation_rejects_leaf_swap_without_external_write
+- id: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  type: module
+  name: test_dag_visualization.py
+  description: Module tests.test_dag_visualization
+- id: a7a447f3-fd94-5b55-b607-8e284c7611b0
+  type: component
+  name: test_reports_are_deterministic_across_input_order_guid_case_and_views
+  description: Function test_reports_are_deterministic_across_input_order_guid_case_and_views
+- id: 03c2e232-954c-54b2-b90b-dc357ffc7699
+  type: component
+  name: test_focus_uses_incoming_and_outgoing_edges_at_each_depth
+  description: Function test_focus_uses_incoming_and_outgoing_edges_at_each_depth
+- id: 500fef8e-a8bb-5ac4-966f-f3b8460d639f
+  type: component
+  name: test_comparison_has_all_classifications_relations_and_exact_source_evidence
+  description: Function test_comparison_has_all_classifications_relations_and_exact_source_evidence
+- id: 823338d0-29ef-57d5-b603-5ea7cb1df204
+  type: component
+  name: test_all_collections_are_bounded_while_totals_remain_complete
+  description: Function test_all_collections_are_bounded_while_totals_remain_complete
+- id: 4ecbb5f6-04a8-54db-a8ee-a13a46b904ef
+  type: component
+  name: test_mermaid_uses_synthetic_ids_and_escapes_bounded_malicious_labels
+  description: Function test_mermaid_uses_synthetic_ids_and_escapes_bounded_malicious_labels
+- id: ff299266-1a04-5373-ab22-611a96af2c34
+  type: component
+  name: test_invalid_dags_arguments_and_read_only_postcondition
+  description: Function test_invalid_dags_arguments_and_read_only_postcondition
+- id: a21dac27-506d-5c62-b72c-472f7e02ef63
+  type: component
+  name: test_project_source_discovery_requires_an_exact_fresh_reality_match
+  description: Function test_project_source_discovery_requires_an_exact_fresh_reality_match
+- id: fd8073eb-3b2a-51ad-b772-89aa132a7354
+  type: component
+  name: test_human_renderer_puts_names_and_sources_before_final_audit_ids
+  description: Function test_human_renderer_puts_names_and_sources_before_final_audit_ids
+- id: 16228d35-7b87-5605-80ef-87afbf6da72a
+  type: component
+  name: test_reality_only_focus_seeds_all_contested_intention_candidates_at_depth_zero
+  description: Function test_reality_only_focus_seeds_all_contested_intention_candidates_at_depth_zero
+- id: 56bf7506-fde4-53c9-83f5-4e9d6be7c720
+  type: component
+  name: test_visualization_canonicalizes_mixed_case_edge_endpoints_before_validation
+  description: Function test_visualization_canonicalizes_mixed_case_edge_endpoints_before_validation
+- id: bb4b8697-a93f-5fae-ac29-7d996f112336
+  type: component
+  name: test_source_location_strings_are_bounded_with_field_truncation_metadata
+  description: Function test_source_location_strings_are_bounded_with_field_truncation_metadata
 - id: bc644a99-9a32-5c73-9d3f-fe9a1f4ff135
   type: module
   name: test_dependency_contract.py
@@ -1992,6 +2097,14 @@ nodes:
   type: component
   name: test_mcp_triage_reconciliation_drift_withholds_unapproved_intent
   description: Function test_mcp_triage_reconciliation_drift_withholds_unapproved_intent
+- id: f3d87bd5-7109-599b-8c17-9b6b6cd075dd
+  type: component
+  name: test_mcp_visualize_matches_cli_and_never_mutates_state
+  description: Function test_mcp_visualize_matches_cli_and_never_mutates_state
+- id: 97553b58-df68-5b73-97a3-83fbb426c741
+  type: component
+  name: test_mcp_visualize_reports_argument_errors
+  description: Function test_mcp_visualize_reports_argument_errors
 - id: 88c3cb2c-8920-5b1f-b2fc-83ca5864101e
   type: component
   name: test_mcp_mapping_review_and_approval_use_source_bound_evidence
@@ -2721,6 +2834,9 @@ edges:
   target: 2b77c80b-27d1-5b82-b03c-3d3c7333d62b
   type: contains
 - source: 51038e11-df2c-549d-b731-bd99dd919ed5
+  target: 3e8a1ea7-2960-5b5d-ab75-4b455163995e
+  type: contains
+- source: 51038e11-df2c-549d-b731-bd99dd919ed5
   target: 65e8c64a-7f28-515f-b34b-d6afa699f8ee
   type: contains
 - source: 51038e11-df2c-549d-b731-bd99dd919ed5
@@ -2833,6 +2949,30 @@ edges:
   type: contains
 - source: 2f396232-c75e-5a6d-b04b-0fa5f940313b
   target: 6a211c50-1e72-581a-9364-627ee51a2f91
+  type: contains
+- source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
+  target: 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58
+  type: contains
+- source: 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58
+  target: bd4d54d7-1bf2-5246-b5a3-261a9c28f36d
+  type: contains
+- source: bd4d54d7-1bf2-5246-b5a3-261a9c28f36d
+  target: 8957d2e8-8aba-511d-834e-d4682f0da437
+  type: contains
+- source: bd4d54d7-1bf2-5246-b5a3-261a9c28f36d
+  target: 36bd5a9b-b93f-5bdb-9c64-9a6da1d6ebfa
+  type: contains
+- source: bd4d54d7-1bf2-5246-b5a3-261a9c28f36d
+  target: 9a39b100-47db-5b5d-bc8f-5b40600c828f
+  type: contains
+- source: 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58
+  target: a630d02a-ba78-57bf-a37b-cd2a8a7b5e90
+  type: contains
+- source: 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58
+  target: 6ac347d4-f1d9-57ca-b4b1-285ad583fead
+  type: contains
+- source: 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58
+  target: a8572269-49b7-58b6-874e-1cbe5cbe0290
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: c3695b6b-abf2-537d-9ed0-0f9df0dfc354
@@ -3049,6 +3189,9 @@ edges:
   type: contains
 - source: 905cfe1d-7c37-50cf-b768-9132c88169e7
   target: a938fadb-83a2-54ff-a2fc-4faa73191a6e
+  type: contains
+- source: 905cfe1d-7c37-50cf-b768-9132c88169e7
+  target: 6c1688ad-cc50-56c2-ac2a-946c11b807d1
   type: contains
 - source: 905cfe1d-7c37-50cf-b768-9132c88169e7
   target: 264ef644-878c-502b-b4a7-d1a47bb29205
@@ -3423,6 +3566,9 @@ edges:
   target: e60aa3fc-6709-53a7-aa41-d2974cb543c2
   type: contains
 - source: f8bef23f-17b8-58a4-95f7-1653f6e4c6cd
+  target: 5c295d8e-7164-5afe-b042-f228de5e5c93
+  type: contains
+- source: f8bef23f-17b8-58a4-95f7-1653f6e4c6cd
   target: 1c07436a-39e8-55f5-a363-5262b6c373cb
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
@@ -3433,6 +3579,9 @@ edges:
   type: contains
 - source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
   target: 1ac3c0fc-933d-526c-bd92-39bbed745d5e
+  type: contains
+- source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
+  target: b033d30f-2bcf-52df-9b9d-9bb377b0be24
   type: contains
 - source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
   target: e639c56f-f276-5fc7-890c-49797276985a
@@ -3454,6 +3603,12 @@ edges:
   type: contains
 - source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
   target: 6053d8a7-3dd0-5235-b10b-133abf806dbf
+  type: contains
+- source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
+  target: d052f200-2690-5b29-8071-88f5473c8c8d
+  type: contains
+- source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
+  target: 57052f55-f22b-5a49-a22e-2ab271f6e666
   type: contains
 - source: ee7a894d-a6a3-54fa-8c01-f5f6549af2fb
   target: e7f83e89-dfc0-5c43-bf0e-23533fe2d987
@@ -3517,6 +3672,42 @@ edges:
   type: contains
 - source: dd81074d-2cb3-55ec-9fa6-1bc151d20385
   target: 4c8577f0-14a0-596a-8d94-2bf2164d5010
+  type: contains
+- source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
+  target: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: a7a447f3-fd94-5b55-b607-8e284c7611b0
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: 03c2e232-954c-54b2-b90b-dc357ffc7699
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: 500fef8e-a8bb-5ac4-966f-f3b8460d639f
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: 823338d0-29ef-57d5-b603-5ea7cb1df204
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: 4ecbb5f6-04a8-54db-a8ee-a13a46b904ef
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: ff299266-1a04-5373-ab22-611a96af2c34
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: a21dac27-506d-5c62-b72c-472f7e02ef63
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: fd8073eb-3b2a-51ad-b772-89aa132a7354
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: 16228d35-7b87-5605-80ef-87afbf6da72a
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: 56bf7506-fde4-53c9-83f5-4e9d6be7c720
+  type: contains
+- source: 7ddd92a5-4ec3-519c-afa3-35674a15b64f
+  target: bb4b8697-a93f-5fae-ac29-7d996f112336
   type: contains
 - source: 719b92f7-5e13-5bca-9990-75f7b431ec3b
   target: bc644a99-9a32-5c73-9d3f-fe9a1f4ff135
@@ -3970,6 +4161,12 @@ edges:
   type: contains
 - source: 300b5e69-1e98-5b6b-8aa0-4b84713d76da
   target: b7b44ed9-31a7-544d-926d-75dfc6b05c91
+  type: contains
+- source: 300b5e69-1e98-5b6b-8aa0-4b84713d76da
+  target: f3d87bd5-7109-599b-8c17-9b6b6cd075dd
+  type: contains
+- source: 300b5e69-1e98-5b6b-8aa0-4b84713d76da
+  target: 97553b58-df68-5b73-97a3-83fbb426c741
   type: contains
 - source: 300b5e69-1e98-5b6b-8aa0-4b84713d76da
   target: 88c3cb2c-8920-5b1f-b2fc-83ca5864101e

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The `aio-agentic-sdlc` framework includes several built-in features that ensure 
 - **Versioned Local State**: The execution backlog uses explicit schema and revision numbers, atomic replacement, stale-writer protection, and a local transaction audit log.
 - **Auditable Intent IR**: Intention nodes can preserve source provenance, assumptions, ambiguities, confidence, evidence-bound acceptance criteria, revision history, and approval state in a strict versioned schema.
 - **Evidence-Gated Reconciliation**: GUID matches are confirmed deterministically, structural matches remain review candidates, and unmatched Reality observations never become deletion work by default.
+- **Read-Only DAG Visualization**: Name-first human, safe Mermaid, and JSON views compare bounded Intention and Reality evidence without exposing raw YAML or mutating framework state.
 - **Approval-Aware Drift Triage**: Safe-plan work is withheld from implementation until accepted intent, Reality observability, and digest-bound classification evidence agree.
 - **SDLC Scribe Agent**: An automated Scribe agent executes before the DevOps agent steps to ensure user-facing documentation (like this README) stays perfectly aligned with the codebase's true reality.
 
@@ -163,7 +164,25 @@ uv run dag-tool triage \
   --max-items 100
 ```
 
-Both commands are read-only. Safe diffing is the default: it asks for mapping review or additional
+Inspect the same canonical workspace without reading raw DAG YAML:
+
+```bash
+uv run dag-tool visualize --project-path /absolute/project \
+  --view comparison --max-items 100 --max-edges 200 --max-candidates 20 \
+  --format human
+uv run dag-tool visualize --project-path /absolute/project \
+  --view comparison --focus-node <guid> --depth 1 --format mermaid
+```
+
+Visualization is read-only and available through the equivalent `visualize_dag` MCP tool. Human
+output leads with names and classifications; Mermaid uses synthetic identifiers and escaped,
+bounded labels. Use JSON to inspect complete totals, truncation, reconciliation details, and exact
+source locations. Source locations are included only when fresh in-memory Reality generation
+exactly matches the loaded canonical Reality DAG, and visualization never claims behavioral
+verification. See [DAG visualization and comparison](doc/dag-visualization.md) for view semantics,
+bounds, self-dogfood commands, and the mapping-review workflow.
+
+Reconciliation and safe diffing are read-only. Safe diffing is the default: it asks for mapping review or additional
 implementation evidence rather than interpreting a missing GUID as permission to create or delete
 code. The historical structural algorithm requires the explicit `--mode legacy-structural` option.
 Both top-level records and nested candidate identities are bounded while complete totals and

--- a/doc/dag-visualization.md
+++ b/doc/dag-visualization.md
@@ -1,0 +1,109 @@
+# DAG visualization and comparison
+
+Use the read-only visualization surface to inspect canonical Intention and Reality DAGs without
+opening or parsing their raw YAML. The CLI and MCP tool load the workspace DAGs, validate them,
+apply deterministic bounds, and render the same report as name-first text, safe Mermaid, or JSON.
+They do not change source, DAG, backlog, audit, or lock state.
+
+## Choose a view
+
+| View | Shows |
+| --- | --- |
+| `intention` | Selected Intention nodes and intended relationships. |
+| `reality` | Selected Reality nodes, observed relationships, and exact source locations when fresh evidence is available. |
+| `comparison` | Intention records classified as `confirmed`, `candidate`, `ambiguous`, or `unmapped`, plus unclassified Reality records and both relationship sets. |
+
+`--focus-node UUID` restricts the report to the focus node and its incoming and outgoing
+neighborhood. `--depth 0` selects only the focus node; larger depths follow both edge directions.
+The focus GUID must exist in the selected view, or in either DAG for `comparison`.
+
+The complete CLI shape is:
+
+```text
+uv run --no-sync dag-tool visualize --project-path PATH \
+  --view intention|reality|comparison [--focus-node UUID] [--depth 1] \
+  [--max-items 100] [--max-edges 200] [--max-candidates 20] \
+  [--format human|mermaid|json]
+```
+
+The MCP equivalent is `visualize_dag`. Pass the absolute repository root as `project_path`; use
+`focus_node_id` and `output_format` for the MCP names of `--focus-node` and `--format`.
+
+## Self-dogfood this repository
+
+From this repository root in PowerShell, inspect the visualization capability and its immediate
+Intention neighborhood:
+
+```powershell
+$projectPath = (Resolve-Path .).Path
+uv run --no-sync dag-tool visualize `
+  --project-path $projectPath `
+  --view comparison `
+  --focus-node 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58 `
+  --depth 1 `
+  --max-items 20 `
+  --max-edges 20 `
+  --max-candidates 5 `
+  --format human
+```
+
+Render the same bounded report as Mermaid for a visual review:
+
+```powershell
+uv run --no-sync dag-tool visualize `
+  --project-path $projectPath `
+  --view comparison `
+  --focus-node 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58 `
+  --depth 1 `
+  --max-items 20 `
+  --max-edges 20 `
+  --max-candidates 5 `
+  --format mermaid
+```
+
+Use JSON when checking complete evidence and truncation metadata:
+
+```powershell
+uv run --no-sync dag-tool visualize `
+  --project-path $projectPath `
+  --view comparison `
+  --focus-node 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58 `
+  --depth 1 `
+  --max-items 20 `
+  --max-edges 20 `
+  --max-candidates 5 `
+  --format json
+```
+
+The human renderer leads with node names, types, and classifications. Mermaid uses synthetic node
+identifiers and bounded, entity-escaped labels; it emits no links, click directives, raw HTML, or
+frontmatter. The JSON renderer exposes the complete report schema for automation and audit.
+
+## Interpret the evidence
+
+- `summary` contains complete available and selected node totals, classification totals, and the
+  total intended and observed relationships in the selected neighborhood.
+- `limits.records` reports the record maximum, complete total, returned count, and truncation.
+  `limits.intended_relationships` and `limits.observed_relationships` do the same independently for
+  edges.
+- `candidate_limit` and each `source_evidence.limit` expose complete nested totals even when
+  `--max-candidates` truncates returned candidates or source locations.
+- `source_discovery.state` is `available` only when an in-memory fresh Reality generation exactly
+  matches the loaded canonical Reality DAG. If generation fails or the snapshots differ, exact
+  source locations are withheld and the reason is reported rather than inferred.
+- `evidence_state.behavioral_verification` is always `unavailable`. Classification, source
+  locations, and related test references establish neither behavioral correctness nor acceptance
+  of the intent.
+
+Human and Mermaid output are concise review surfaces. Use JSON whenever complete limit,
+truncation, source-location, or reconciliation evidence must be audited.
+
+## Use visualization in mapping review
+
+Before asking a human to approve an Intention-to-Reality identity mapping, present a
+`comparison` view in human or Mermaid format. It provides orientation across intended and observed
+names, identities, and relationships, but it is not an approval artifact.
+
+Then run `review_mapping` immediately before the decision and present its fresh, source-bound human
+decision brief. Only `approve_mapping` consumes the exact reviewed candidate and evidence digest.
+Visualization does not replace that two-step gate, prove behavior, or authorize a mapping.

--- a/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
+++ b/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aio-agentic-sdlc",
-  "version": "0.21.0+codex.20260815195955",
+  "version": "0.21.0+codex.20260817170722",
   "description": "Run a traceable, dual-DAG software delivery workflow with Codex and the AIO Agentic SDLC MCP tools.",
   "author": {
     "name": "aegolius-labs",
@@ -21,16 +21,20 @@
   "interface": {
     "displayName": "AIO Agentic SDLC",
     "shortDescription": "Traceable dual-DAG planning and delivery",
-    "longDescription": "Plan requirements, prioritize graph-backed work, orchestrate implementation and QA, reconcile intention with repository reality, and triage drift before execution.",
+    "longDescription": "Plan requirements, prioritize graph-backed work, orchestrate implementation and QA, visualize and reconcile intention with repository reality, and triage drift before execution.",
     "developerName": "aegolius-labs",
     "category": "Engineering",
-    "capabilities": ["Read", "Write"],
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
     "websiteURL": "https://github.com/aegolius-labs/aio-agentic-sdlc",
     "defaultPrompt": [
       "Turn this feature idea into a traceable PRD.",
       "Run this change through the agentic SDLC pipeline.",
       "Show me the highest-priority unblocked task.",
-      "Triage reconciliation drift and show only approved implementation work."
+      "Triage reconciliation drift and show only approved implementation work.",
+      "Visualize the Intention and Reality DAG comparison before mapping approval."
     ]
   }
 }

--- a/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
+++ b/plugins/aio-agentic-sdlc/.codex-plugin/plugin.json
@@ -24,10 +24,7 @@
     "longDescription": "Plan requirements, prioritize graph-backed work, orchestrate implementation and QA, visualize and reconcile intention with repository reality, and triage drift before execution.",
     "developerName": "aegolius-labs",
     "category": "Engineering",
-    "capabilities": [
-      "Read",
-      "Write"
-    ],
+    "capabilities": ["Read", "Write"],
     "websiteURL": "https://github.com/aegolius-labs/aio-agentic-sdlc",
     "defaultPrompt": [
       "Turn this feature idea into a traceable PRD.",

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/pipeline.md
@@ -30,13 +30,15 @@ digest as stale after either canonical DAG changes. Only items classified as
 Route `obsolete_or_unapproved_intent` to Intake/Architecture and
 `framework_tooling_drift` to framework maintenance; never convert either into product code work.
 
-When reconciliation yields exactly one supported structural candidate, run `review_mapping` and
-present its human decision brief. Ask an authorized human whether the implementation responsibility,
-public surface, documentation, and related-test evidence justify linking the candidate to the
-Intention node. Structural matching and test references are not behavioral proof, so defer is the
-default. Only after an explicit identity-linkage decision may `approve_mapping` atomically add the
-canonical source marker and audit receipt. GUIDs and the digest are audit inputs, and any changed
-digest, intent, or source requires a new review and approval.
+When reconciliation yields exactly one supported structural candidate, run `visualize_dag` with
+`view=comparison` and present a human or Mermaid comparison before asking for identity approval.
+Then run `review_mapping` and present its human decision brief. Ask an authorized human whether the
+implementation responsibility, public surface, documentation, and related-test evidence justify
+linking the candidate to the Intention node. Visualization, structural matching, and test references
+are not behavioral proof, so defer is the default. Only after an explicit identity-linkage decision
+may `approve_mapping` atomically add the canonical source marker and audit receipt. GUIDs and the
+digest are audit inputs, and any changed digest, intent, or source requires a new review and
+approval.
 
 ## 4. Implementation
 

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/roles/cartographer.md
@@ -12,20 +12,24 @@ Reconcile intended architecture with repository reality through deterministic to
    structural matches remain approval-required candidates, and unmatched Reality observations are
    unclassified rather than deletion candidates. Keep both record and nested-candidate limits
    bounded, and retain their complete totals and truncation metadata.
-5. For one unique structural candidate, run `review_mapping` and present the human decision brief:
+5. Before asking for mapping identity approval, run `visualize_dag` with `view=comparison` and
+   present its human or Mermaid output. Keep node, edge, and nested-candidate limits bounded. Treat
+   the visualization as orientation, not behavioral proof or an approval artifact; exact source
+   locations are fresh only when in-memory Reality generation exactly matches canonical Reality.
+6. For one unique structural candidate, run `review_mapping` and present the human decision brief:
    intended responsibility and criteria, implementation documentation and public API, related tests,
    and unresolved gaps. State that test references are not proof and mapping links identity rather
    than approving behavior. Put source-bound GUIDs and the digest last as audit metadata. Call
    `approve_mapping` only after an authorized human explicitly approves that exact identity linkage
    and supplies the approver identity, timezone-aware time, and rationale. Never infer approval or
    approve ambiguous, unmapped, unsupported, stale, or mismatched evidence.
-6. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
-7. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
-8. Run `triage_reconciliation_drift` before routing work. Withhold non-approved intent, reject stale
+7. Run `validate_traceability` against the generated Reality DAG, Intention DAG, specs, and source.
+8. Classify mismatches as reality drift, intention drift, or framework-tooling drift.
+9. Run `triage_reconciliation_drift` before routing work. Withhold non-approved intent, reject stale
    decision digests, and send only explicitly actionable missing implementation to the orchestrator.
-9. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
-10. After QA acceptance, use `promote_spec` for the exact accepted artifact.
-11. Re-run reconciliation, triage, and traceability validation after promotion or material state
+10. Report drift to the orchestrator; do not patch DAG files or generated metadata manually.
+11. After QA acceptance, use `promote_spec` for the exact accepted artifact.
+12. Re-run reconciliation, triage, and traceability validation after promotion or material state
     changes.
 
 Return a concise status, affected GUIDs and paths, drift classification, and tool output summary.

--- a/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
+++ b/plugins/aio-agentic-sdlc/skills/manage-sdlc/references/tools.md
@@ -16,6 +16,7 @@ Tool names may be namespaced by the Codex host. Match them by the operation name
 | Validate GUID links | `validate_traceability` | Use the Python API if MCP is unavailable |
 | Generate Reality DAG | `generate_reality` | `uv run dag-tool generate-reality ...` |
 | Reconcile DAG identity evidence | `reconcile_dags` | `uv run dag-tool reconcile ...` |
+| Visualize or compare canonical DAGs | `visualize_dag` | `uv run dag-tool visualize --project-path ... --view ...` |
 | Triage reconciliation drift | `triage_reconciliation_drift` | `uv run dag-tool triage ...` |
 | Review a source mapping | `review_mapping` | `uv run dag-tool mapping review ...` |
 | Approve an exact reviewed mapping | `approve_mapping` | `uv run dag-tool mapping approve ...` |
@@ -41,8 +42,16 @@ timezone-aware timestamp. Only `missing_implementation` on approved intent may b
 implementer; tooling drift goes to the framework, and obsolete or unapproved intent goes back to
 Intake/Architecture.
 
+Use `visualize_dag` for read-only `intention`, `reality`, or `comparison` views; no raw-YAML review
+is required. Prefer name-first `human` output for a concise brief, `mermaid` for a graph, and `json`
+for complete limits, totals, truncation, and evidence. Keep `max_items`, `max_edges`, and
+`max_candidates` bounded. Exact source locations are available only when fresh in-memory Reality
+generation exactly matches the loaded canonical Reality DAG; visualization does not establish
+behavioral verification.
+
 Mapping is a two-step approval gate. Run `review_mapping` immediately before presenting a decision.
-Present the decision brief first: intended responsibility and acceptance criteria, actual symbol
+Before asking for identity approval, also present a human or Mermaid `comparison` from
+`visualize_dag`. Then present the decision brief: intended responsibility and acceptance criteria, actual symbol
 documentation and public API, related tests, and unresolved gaps. Explain that test references are
 not proof and that approval links identity rather than approving behavior. Show GUIDs and the digest
 last as audit inputs. Call `approve_mapping` only after an authorized human explicitly accepts that

--- a/src/aio_agentic_sdlc/dag_cli.py
+++ b/src/aio_agentic_sdlc/dag_cli.py
@@ -14,6 +14,7 @@ from aio_agentic_sdlc.dag_store import (
     guarded_file_path,
     mutate_dag_file,
 )
+from aio_agentic_sdlc.dag_visualization import DAGVisualizationEngine, render_dag
 from aio_agentic_sdlc.diffing_engine import DiffingEngine, DiffPolicy
 from aio_agentic_sdlc.drift_triage import (
     DriftTriageEngine,
@@ -567,6 +568,84 @@ def reconcile(intention, reality, max_items, max_candidates, output):
             click.echo(json.dumps(report, indent=2))
     except Exception as e:
         click.secho(f"Error reconciling DAGs: {str(e)}", err=True, fg="red")
+        sys.exit(1)
+
+
+@cli.command("visualize")
+@click.option(
+    "--project-path",
+    required=True,
+    type=click.Path(exists=True, file_okay=False),
+    help="Path to the project containing the canonical framework workspace.",
+)
+@click.option(
+    "--view",
+    required=True,
+    type=click.Choice(["intention", "reality", "comparison"], case_sensitive=False),
+    help="DAG view to render.",
+)
+@click.option("--focus-node", "focus_node_id", help="Canonical node GUID to focus.")
+@click.option(
+    "--depth",
+    type=click.IntRange(min=0),
+    default=1,
+    show_default=True,
+    help="Incoming and outgoing neighborhood depth.",
+)
+@click.option(
+    "--max-items",
+    type=click.IntRange(min=1),
+    default=100,
+    show_default=True,
+    help="Maximum records returned without hiding complete totals.",
+)
+@click.option(
+    "--max-edges",
+    type=click.IntRange(min=1),
+    default=200,
+    show_default=True,
+    help="Maximum intended and observed relationships returned per collection.",
+)
+@click.option(
+    "--max-candidates",
+    type=click.IntRange(min=1),
+    default=20,
+    show_default=True,
+    help="Maximum identity candidates and nested source locations per record.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["human", "mermaid", "json"], case_sensitive=False),
+    default="human",
+    show_default=True,
+    help="Output rendering format.",
+)
+def visualize(
+    project_path,
+    view,
+    focus_node_id,
+    depth,
+    max_items,
+    max_edges,
+    max_candidates,
+    output_format,
+):
+    """Render canonical DAGs without mutating project or framework state."""
+
+    try:
+        engine = DAGVisualizationEngine.from_project(project_path)
+        report = engine.build_report(
+            view=view,
+            focus_node_id=focus_node_id,
+            depth=depth,
+            max_items=max_items,
+            max_edges=max_edges,
+            max_candidates=max_candidates,
+        )
+        click.echo(render_dag(report, output_format))
+    except Exception as e:
+        click.secho(f"Error visualizing DAGs: {str(e)}", err=True, fg="red")
         sys.exit(1)
 
 

--- a/src/aio_agentic_sdlc/dag_manager.py
+++ b/src/aio_agentic_sdlc/dag_manager.py
@@ -10,7 +10,13 @@ from aio_agentic_sdlc.dag_models import Edge, EdgeType, Metadata, Node
 class DAGManager:
     def __init__(self, metadata: Metadata, nodes: List[Node], edges: List[Edge]):
         self.metadata = metadata
-        self.nodes: Dict[str, Node] = {n.id: n for n in nodes}
+        raw_nodes = list(nodes)
+        seen_ids: set[str] = set()
+        for node in raw_nodes:
+            if node.id in seen_ids:
+                raise ValueError(f"Duplicate node ID {node.id}.")
+            seen_ids.add(node.id)
+        self.nodes: Dict[str, Node] = {n.id: n for n in raw_nodes}
         self.edges: List[Edge] = edges
 
     @classmethod

--- a/src/aio_agentic_sdlc/dag_visualization.py
+++ b/src/aio_agentic_sdlc/dag_visualization.py
@@ -1,0 +1,963 @@
+# aio-sdlc-node: 841ddc3e-b7a2-57d3-80f1-bfb5ef9c6f58
+"""Read-only, deterministic DAG visualization and comparison reports."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+from collections import deque
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import Edge, Node
+from aio_agentic_sdlc.reality_dag_generator import RealityDAGGenerator
+from aio_agentic_sdlc.reconciliation import ReconciliationEngine, normalize_node_name
+from aio_agentic_sdlc.source_locations import SourceLocation
+from aio_agentic_sdlc.workspace import INTENTION_DAG_FILE, REALITY_DAG_FILE
+
+REPORT_SCHEMA_VERSION = 1
+DEFAULT_MAX_ITEMS = 100
+DEFAULT_MAX_EDGES = 200
+DEFAULT_MAX_CANDIDATES = 20
+MAX_REPORT_TEXT = 200
+MAX_MERMAID_LABEL = 120
+SUPPORTED_VIEWS = {"intention", "reality", "comparison"}
+CLASSIFICATIONS = ("confirmed", "candidate", "ambiguous", "unmapped")
+
+
+def _canonical_guid(value: str) -> str:
+    return str(UUID(value))
+
+
+def _validate_integer(value: int, *, name: str, minimum: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    if value < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+
+
+def _bounded_text(value: Any, limit: int = MAX_REPORT_TEXT) -> tuple[str, bool]:
+    text = str(value)
+    if len(text) <= limit:
+        return text, False
+    return text[:limit], True
+
+
+def _bounded_value(value: Any) -> Any:
+    """Bound strings in small, engine-owned reconciliation evidence structures."""
+
+    if isinstance(value, str):
+        return _bounded_text(value)[0]
+    if isinstance(value, dict):
+        return {str(key): _bounded_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_bounded_value(item) for item in value]
+    return value
+
+
+def _normalize_dag(manager: DAGManager, *, dag_name: str) -> DAGManager:
+    """Return a canonical-GUID copy without changing the supplied manager."""
+
+    canonical_sources: dict[str, str] = {}
+    nodes: list[Node] = []
+    for source_id, node in manager.nodes.items():
+        canonical_id = _canonical_guid(source_id)
+        if canonical_id in canonical_sources:
+            raise ValueError(
+                f"{dag_name} contains duplicate canonical GUID {canonical_id}: "
+                f"{canonical_sources[canonical_id]} and {source_id}"
+            )
+        canonical_sources[canonical_id] = source_id
+        nodes.append(node.model_copy(update={"id": canonical_id}))
+
+    edges = [
+        edge.model_copy(
+            update={
+                "source": _canonical_guid(edge.source),
+                "target": _canonical_guid(edge.target),
+            }
+        )
+        for edge in manager.edges
+    ]
+    normalized = DAGManager(manager.metadata.model_copy(), nodes, edges)
+    normalized.validate()
+    return normalized
+
+
+def _node_report(node: Node) -> dict[str, Any]:
+    name, name_truncated = _bounded_text(node.name)
+    report: dict[str, Any] = {
+        "id": _canonical_guid(node.id),
+        "type": node.type.value,
+        "name": name,
+        "name_truncated": name_truncated,
+    }
+    if node.domain is not None:
+        domain, domain_truncated = _bounded_text(node.domain)
+        report.update({"domain": domain, "domain_truncated": domain_truncated})
+    if node.description is not None:
+        description, description_truncated = _bounded_text(node.description)
+        report.update(
+            {
+                "description": description,
+                "description_truncated": description_truncated,
+            }
+        )
+    return report
+
+
+def _edge_sort_key(edge: Edge) -> tuple[str, str, str, str]:
+    return (
+        _canonical_guid(edge.source),
+        _canonical_guid(edge.target),
+        edge.type.value,
+        edge.description or "",
+    )
+
+
+def _edge_report(edge: Edge) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "source_id": _canonical_guid(edge.source),
+        "target_id": _canonical_guid(edge.target),
+        "type": edge.type.value,
+    }
+    if edge.description is not None:
+        description, description_truncated = _bounded_text(edge.description)
+        report.update(
+            {
+                "description": description,
+                "description_truncated": description_truncated,
+            }
+        )
+    return report
+
+
+def _dag_signature(manager: DAGManager) -> str:
+    """Return a stable exact signature for one already-normalized DAG."""
+
+    nodes = [
+        manager.nodes[node_id].model_dump(mode="json", exclude_none=True)
+        for node_id in sorted(manager.nodes)
+    ]
+    edges = [
+        edge.model_dump(mode="json", exclude_none=True)
+        for edge in sorted(manager.edges, key=_edge_sort_key)
+    ]
+    payload = {
+        "metadata": manager.metadata.model_dump(mode="json", exclude_none=True),
+        "nodes": nodes,
+        "edges": edges,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _collection_limit(
+    *, name: str, maximum: int, total: int, returned: int
+) -> dict[str, Any]:
+    return {
+        name: maximum,
+        "total_items" if name == "max_items" else "total_edges": total,
+        "returned_items" if name == "max_items" else "returned_edges": returned,
+        "truncated": returned < total,
+    }
+
+
+class DAGVisualizationEngine:
+    """Build one bounded report from validated canonical DAG snapshots."""
+
+    def __init__(
+        self,
+        intention: DAGManager,
+        reality: DAGManager,
+        *,
+        source_locations: (
+            Mapping[str, Iterable[SourceLocation | Mapping[str, Any]]] | None
+        ) = None,
+        source_discovery: Mapping[str, str] | None = None,
+    ):
+        self.intention = _normalize_dag(intention, dag_name="Intention DAG")
+        self.reality = _normalize_dag(reality, dag_name="Reality DAG")
+        self.source_locations = self._normalize_source_locations(source_locations or {})
+        self.source_discovery = dict(
+            source_discovery
+            or (
+                {
+                    "state": "available",
+                    "reason": "Exact SourceLocation evidence was supplied.",
+                }
+                if self.source_locations
+                else {
+                    "state": "unavailable",
+                    "reason": "No exact SourceLocation evidence was supplied.",
+                }
+            )
+        )
+        self.reconciliation = ReconciliationEngine(self.intention, self.reality)
+
+    @classmethod
+    def from_project(cls, project_path: str | Path) -> "DAGVisualizationEngine":
+        """Load canonical state and admit fresh source locations only on exact match."""
+
+        project_root = Path(project_path).resolve()
+        intention = DAGManager.load(str(project_root / INTENTION_DAG_FILE))
+        reality = DAGManager.load(str(project_root / REALITY_DAG_FILE))
+        engine = cls(intention, reality)
+
+        try:
+            generator = RealityDAGGenerator(
+                root_dir=str(project_root),
+                system_name=reality.metadata.name,
+            )
+            generated_reality = _normalize_dag(
+                generator.generate(),
+                dag_name="Fresh Reality DAG",
+            )
+            if _dag_signature(generated_reality) != _dag_signature(engine.reality):
+                engine.source_discovery = {
+                    "state": "unavailable",
+                    "reason": (
+                        "Fresh generated Reality does not match the loaded canonical "
+                        "Reality DAG."
+                    ),
+                }
+                return engine
+            engine.source_locations = engine._normalize_source_locations(
+                generator.source_locations
+            )
+            engine.source_discovery = {
+                "state": "available",
+                "reason": (
+                    "Fresh generated Reality exactly matches the loaded canonical "
+                    "Reality DAG."
+                ),
+            }
+        except Exception as exc:
+            detail = _bounded_text(str(exc), limit=120)[0]
+            engine.source_locations = {}
+            engine.source_discovery = {
+                "state": "unavailable",
+                "reason": f"Fresh source discovery failed: {detail}",
+            }
+        return engine
+
+    @staticmethod
+    def _normalize_source_locations(
+        locations: Mapping[str, Iterable[SourceLocation | Mapping[str, Any]]],
+    ) -> dict[str, list[SourceLocation]]:
+        normalized: dict[str, list[SourceLocation]] = {}
+        for source_id, values in locations.items():
+            canonical_id = _canonical_guid(source_id)
+            retained = normalized.setdefault(canonical_id, [])
+            for value in values:
+                location = (
+                    value
+                    if isinstance(value, SourceLocation)
+                    else SourceLocation(**dict(value))
+                )
+                if location not in retained:
+                    retained.append(location)
+        for values in normalized.values():
+            values.sort(
+                key=lambda location: (
+                    location.path,
+                    location.definition_line,
+                    location.marker_line,
+                    location.symbol_kind,
+                    location.symbol_name,
+                    location.source_sha256,
+                )
+            )
+        return normalized
+
+    @staticmethod
+    def _distances(
+        manager: DAGManager,
+        focus_node_id: str | None,
+        depth: int,
+    ) -> dict[str, int]:
+        if focus_node_id is None:
+            return {node_id: 0 for node_id in manager.nodes}
+        if focus_node_id not in manager.nodes:
+            return {}
+
+        adjacency = {node_id: set() for node_id in manager.nodes}
+        for edge in manager.edges:
+            adjacency[edge.source].add(edge.target)
+            adjacency[edge.target].add(edge.source)
+
+        distances = {focus_node_id: 0}
+        pending = deque([focus_node_id])
+        while pending:
+            current = pending.popleft()
+            current_distance = distances[current]
+            if current_distance == depth:
+                continue
+            for neighbor in sorted(adjacency[current]):
+                if neighbor in distances:
+                    continue
+                distances[neighbor] = current_distance + 1
+                pending.append(neighbor)
+        return distances
+
+    @staticmethod
+    def _seeded_distances(
+        manager: DAGManager,
+        seeds: set[str],
+        depth: int,
+    ) -> dict[str, int]:
+        if not seeds:
+            return {}
+        adjacency = {node_id: set() for node_id in manager.nodes}
+        for edge in manager.edges:
+            adjacency[edge.source].add(edge.target)
+            adjacency[edge.target].add(edge.source)
+
+        distances = {node_id: 0 for node_id in seeds}
+        pending = deque(sorted(seeds))
+        while pending:
+            current = pending.popleft()
+            current_distance = distances[current]
+            if current_distance == depth:
+                continue
+            for neighbor in sorted(adjacency[current]):
+                proposed_distance = current_distance + 1
+                if neighbor in distances and distances[neighbor] <= proposed_distance:
+                    continue
+                distances[neighbor] = proposed_distance
+                pending.append(neighbor)
+        return distances
+
+    def _source_evidence(
+        self,
+        reality_id: str,
+        *,
+        max_candidates: int,
+    ) -> dict[str, Any]:
+        locations = self.source_locations.get(reality_id, [])
+        retained = locations[:max_candidates]
+        location_reports: list[dict[str, Any]] = []
+        location_truncation: list[dict[str, bool]] = []
+        for location in retained:
+            fields: dict[str, str] = {}
+            truncation: dict[str, bool] = {}
+            for field in ("path", "symbol_kind", "symbol_name", "source_sha256"):
+                fields[field], truncation[field] = _bounded_text(
+                    getattr(location, field)
+                )
+            location_reports.append(
+                {
+                    "path": fields["path"],
+                    "symbol_kind": fields["symbol_kind"],
+                    "symbol_name": fields["symbol_name"],
+                    "definition_line": location.definition_line,
+                    "marker_line": location.marker_line,
+                    "source_sha256": fields["source_sha256"],
+                }
+            )
+            location_truncation.append(truncation)
+        return {
+            "state": "available" if retained else "unavailable",
+            "locations": location_reports,
+            "location_truncation": location_truncation,
+            "limit": _collection_limit(
+                name="max_items",
+                maximum=max_candidates,
+                total=len(locations),
+                returned=len(retained),
+            ),
+            **(
+                {}
+                if retained
+                else {"reason": "No exact SourceLocation evidence was supplied."}
+            ),
+        }
+
+    @staticmethod
+    def _evidence_state(
+        *, identity_available: bool, source_available: bool
+    ) -> dict[str, str]:
+        return {
+            "identity": "available" if identity_available else "unavailable",
+            "source": "available" if source_available else "unavailable",
+            "behavioral_verification": "unavailable",
+        }
+
+    def _intention_record(self, node_id: str, *, distance: int) -> dict[str, Any]:
+        return {
+            "canonical_id": node_id,
+            "subject_kind": "intention",
+            "distance": distance,
+            "intention": _node_report(self.intention.nodes[node_id]),
+            "evidence_state": self._evidence_state(
+                identity_available=False,
+                source_available=False,
+            ),
+        }
+
+    def _reality_record(
+        self,
+        node_id: str,
+        *,
+        distance: int,
+        max_candidates: int,
+        classification: str | None = None,
+    ) -> dict[str, Any]:
+        source_evidence = self._source_evidence(
+            node_id,
+            max_candidates=max_candidates,
+        )
+        record = {
+            "canonical_id": node_id,
+            "subject_kind": "reality",
+            "distance": distance,
+            "reality": _node_report(self.reality.nodes[node_id]),
+            "source_evidence": source_evidence,
+            "evidence_state": self._evidence_state(
+                identity_available=False,
+                source_available=source_evidence["state"] == "available",
+            ),
+        }
+        if classification is not None:
+            record["classification"] = classification
+        return record
+
+    def _comparison_intent_record(
+        self,
+        reconciliation_record: dict[str, Any],
+        *,
+        distance: int,
+        max_candidates: int,
+        preferred_reality_id: str | None = None,
+    ) -> dict[str, Any]:
+        intent_id = _canonical_guid(reconciliation_record["intent"]["id"])
+        reality_candidates: list[dict[str, Any]] = []
+        source_available = False
+        candidate_summaries = list(reconciliation_record["reality_candidates"])
+        if preferred_reality_id is not None and not any(
+            _canonical_guid(candidate["id"]) == preferred_reality_id
+            for candidate in candidate_summaries
+        ):
+            preferred = self.reality.nodes[preferred_reality_id]
+            preferred_summary = {
+                "id": preferred.id,
+                "type": preferred.type.value,
+                "name": preferred.name,
+            }
+            if len(candidate_summaries) == max_candidates:
+                candidate_summaries[-1] = preferred_summary
+            else:
+                candidate_summaries.append(preferred_summary)
+        candidate_summaries.sort(
+            key=lambda candidate: (
+                _canonical_guid(candidate["id"]) != preferred_reality_id,
+                _canonical_guid(candidate["id"]),
+            )
+        )
+        for candidate in candidate_summaries:
+            candidate_id = _canonical_guid(candidate["id"])
+            source_evidence = self._source_evidence(
+                candidate_id,
+                max_candidates=max_candidates,
+            )
+            source_available = (
+                source_available or source_evidence["state"] == "available"
+            )
+            candidate_report = _node_report(self.reality.nodes[candidate_id])
+            candidate_report["source_evidence"] = source_evidence
+            reality_candidates.append(candidate_report)
+        reality_candidates.sort(key=lambda candidate: candidate["id"])
+
+        total_candidates = reconciliation_record.get("candidate_limit", {}).get(
+            "total_candidates", len(reality_candidates)
+        )
+        candidate_limit = {
+            "max_candidates": max_candidates,
+            "total_candidates": total_candidates,
+            "returned_candidates": len(reality_candidates),
+            "truncated": len(reality_candidates) < total_candidates,
+        }
+        identity_evidence = _bounded_value(reconciliation_record.get("evidence", []))
+        return {
+            "canonical_id": intent_id,
+            "subject_kind": "intent",
+            "distance": distance,
+            "classification": reconciliation_record["classification"],
+            "intention": _node_report(self.intention.nodes[intent_id]),
+            "reality_candidates": reality_candidates,
+            "candidate_limit": candidate_limit,
+            "identity_evidence": identity_evidence,
+            "requires_approval": reconciliation_record["requires_approval"],
+            "evidence_state": self._evidence_state(
+                identity_available=bool(identity_evidence),
+                source_available=source_available,
+            ),
+        }
+
+    @staticmethod
+    def _bounded_relationships(
+        manager: DAGManager,
+        selected_ids: set[str],
+        *,
+        max_edges: int,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        total = 0
+        retained: list[Edge] = []
+        for edge in manager.edges:
+            if edge.source not in selected_ids or edge.target not in selected_ids:
+                continue
+            total += 1
+            if len(retained) < max_edges:
+                retained.append(edge)
+                retained.sort(key=_edge_sort_key)
+            elif _edge_sort_key(edge) < _edge_sort_key(retained[-1]):
+                retained[-1] = edge
+                retained.sort(key=_edge_sort_key)
+        return (
+            [_edge_report(edge) for edge in retained],
+            _collection_limit(
+                name="max_edges",
+                maximum=max_edges,
+                total=total,
+                returned=len(retained),
+            ),
+        )
+
+    def build_report(
+        self,
+        *,
+        view: str = "comparison",
+        focus_node_id: str | None = None,
+        depth: int = 1,
+        max_items: int = DEFAULT_MAX_ITEMS,
+        max_edges: int = DEFAULT_MAX_EDGES,
+        max_candidates: int = DEFAULT_MAX_CANDIDATES,
+    ) -> dict[str, Any]:
+        """Build one deterministic bounded view without mutating either DAG."""
+
+        if not isinstance(view, str) or view.casefold() not in SUPPORTED_VIEWS:
+            raise ValueError(f"Unsupported view: {view}")
+        view = view.casefold()
+        _validate_integer(depth, name="depth", minimum=0)
+        _validate_integer(max_items, name="max_items", minimum=1)
+        _validate_integer(max_edges, name="max_edges", minimum=1)
+        _validate_integer(max_candidates, name="max_candidates", minimum=1)
+
+        focus_id = _canonical_guid(focus_node_id) if focus_node_id is not None else None
+        focus_in_intention = focus_id is not None and focus_id in self.intention.nodes
+        focus_in_reality = focus_id is not None and focus_id in self.reality.nodes
+        focus_is_known = (
+            focus_in_intention
+            if view == "intention"
+            else (
+                focus_in_reality
+                if view == "reality"
+                else focus_in_intention or focus_in_reality
+            )
+        )
+        if focus_id is not None and not focus_is_known:
+            raise ValueError(f"Unknown focus node for {view} view: {focus_id}")
+
+        intention_distances = self._distances(
+            self.intention,
+            focus_id if focus_in_intention else None,
+            depth,
+        )
+        reality_distances = self._distances(
+            self.reality,
+            focus_id if focus_in_reality else None,
+            depth,
+        )
+        if focus_id is not None and not focus_in_intention:
+            intention_distances = {}
+        if focus_id is not None and not focus_in_reality:
+            reality_distances = {}
+
+        focused_candidate_intent_ids: set[str] = set()
+        if view == "comparison" and focus_in_reality and not focus_in_intention:
+            focused_reality = self.reality.nodes[focus_id]
+            normalized_focus_name = normalize_node_name(focused_reality.name)
+            if normalized_focus_name:
+                focused_candidate_intent_ids = {
+                    intent_id
+                    for intent_id, intent_node in self.intention.nodes.items()
+                    if intent_node.type == focused_reality.type
+                    and normalize_node_name(intent_node.name) == normalized_focus_name
+                }
+            intention_distances = self._seeded_distances(
+                self.intention,
+                focused_candidate_intent_ids,
+                depth,
+            )
+
+        records: list[dict[str, Any]] = []
+        classification_counts = {
+            classification: 0 for classification in CLASSIFICATIONS
+        }
+        if view == "intention":
+            ordered = sorted(
+                intention_distances.items(),
+                key=lambda item: (item[1], item[0]),
+            )
+            total_records = len(ordered)
+            records = [
+                self._intention_record(node_id, distance=distance)
+                for node_id, distance in ordered[:max_items]
+            ]
+        elif view == "reality":
+            ordered = sorted(
+                reality_distances.items(),
+                key=lambda item: (item[1], item[0]),
+            )
+            total_records = len(ordered)
+            records = [
+                self._reality_record(
+                    node_id,
+                    distance=distance,
+                    max_candidates=max_candidates,
+                )
+                for node_id, distance in ordered[:max_items]
+            ]
+        else:
+            descriptors: list[
+                tuple[tuple[int, str, str], str, dict[str, Any] | str]
+            ] = []
+
+            def retain_descriptor(
+                sort_key: tuple[int, str, str],
+                kind: str,
+                payload: dict[str, Any] | str,
+            ) -> None:
+                descriptor = (sort_key, kind, payload)
+                if len(descriptors) < max_items:
+                    descriptors.append(descriptor)
+                    descriptors.sort(key=lambda item: item[0])
+                elif sort_key < descriptors[-1][0]:
+                    descriptors[-1] = descriptor
+                    descriptors.sort(key=lambda item: item[0])
+
+            confirmed_reality_ids: set[str] = set()
+            total_records = 0
+            for reconciliation_record in self.reconciliation.iter_intent_records(
+                max_candidates=max_candidates
+            ):
+                intent_id = _canonical_guid(reconciliation_record["intent"]["id"])
+                if reconciliation_record["classification"] == "confirmed":
+                    confirmed_reality_ids.update(
+                        _canonical_guid(candidate["id"])
+                        for candidate in reconciliation_record["reality_candidates"]
+                    )
+                if intent_id not in intention_distances:
+                    continue
+                classification_counts[reconciliation_record["classification"]] += 1
+                total_records += 1
+                retain_descriptor(
+                    (intention_distances[intent_id], intent_id, "intent"),
+                    "intent",
+                    reconciliation_record,
+                )
+            for reality_id, distance in reality_distances.items():
+                if reality_id in confirmed_reality_ids:
+                    continue
+                total_records += 1
+                retain_descriptor(
+                    (distance, reality_id, "reality"),
+                    "reality",
+                    reality_id,
+                )
+            for sort_key, kind, payload in descriptors:
+                if kind == "intent":
+                    assert isinstance(payload, dict)
+                    records.append(
+                        self._comparison_intent_record(
+                            payload,
+                            distance=sort_key[0],
+                            max_candidates=max_candidates,
+                            preferred_reality_id=(
+                                focus_id
+                                if payload["intent"]["id"]
+                                in focused_candidate_intent_ids
+                                else None
+                            ),
+                        )
+                    )
+                else:
+                    assert isinstance(payload, str)
+                    records.append(
+                        self._reality_record(
+                            payload,
+                            distance=sort_key[0],
+                            max_candidates=max_candidates,
+                            classification="unclassified_reality",
+                        )
+                    )
+
+        selected_intention_ids = set(intention_distances)
+        selected_reality_ids = set(reality_distances)
+        if view == "reality":
+            intended_relationships: list[dict[str, Any]] = []
+            intended_limit = _collection_limit(
+                name="max_edges", maximum=max_edges, total=0, returned=0
+            )
+        else:
+            intended_relationships, intended_limit = self._bounded_relationships(
+                self.intention,
+                selected_intention_ids,
+                max_edges=max_edges,
+            )
+        if view == "intention":
+            observed_relationships: list[dict[str, Any]] = []
+            observed_limit = _collection_limit(
+                name="max_edges", maximum=max_edges, total=0, returned=0
+            )
+        else:
+            observed_relationships, observed_limit = self._bounded_relationships(
+                self.reality,
+                selected_reality_ids,
+                max_edges=max_edges,
+            )
+
+        return {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "view": view,
+            "focus": {"node_id": focus_id, "depth": depth},
+            "source_discovery": self.source_discovery,
+            "summary": {
+                "available_intention_nodes": len(self.intention.nodes),
+                "available_reality_nodes": len(self.reality.nodes),
+                "selected_intention_nodes": len(selected_intention_ids),
+                "selected_reality_nodes": len(selected_reality_ids),
+                "classifications": classification_counts,
+                "intended_relationships": intended_limit["total_edges"],
+                "observed_relationships": observed_limit["total_edges"],
+            },
+            "limits": {
+                "records": _collection_limit(
+                    name="max_items",
+                    maximum=max_items,
+                    total=total_records,
+                    returned=len(records),
+                ),
+                "intended_relationships": intended_limit,
+                "observed_relationships": observed_limit,
+            },
+            "records": records,
+            "intended_relationships": intended_relationships,
+            "observed_relationships": observed_relationships,
+        }
+
+
+def _plain_label(value: Any, *, limit: int = MAX_MERMAID_LABEL) -> str:
+    text = re.sub(r"[\x00-\x1f\x7f]+", " ", str(value))
+    text = " ".join(text.split())
+    if len(text) > limit:
+        text = text[: limit - 1] + "…"
+    return text
+
+
+def _mermaid_label(value: Any) -> str:
+    escaped = html.escape(_plain_label(value), quote=True)
+    return escaped.replace("%", "&#37;")
+
+
+def _record_entities(
+    report: Mapping[str, Any],
+) -> tuple[
+    list[tuple[tuple[str, str], str]],
+    list[tuple[tuple[str, str], tuple[str, str], str]],
+]:
+    entities: dict[tuple[str, str], str] = {}
+    identity_edges: list[tuple[tuple[str, str], tuple[str, str], str]] = []
+    for record in report.get("records", []):
+        if record["subject_kind"] in {"intention", "intent"}:
+            node = record["intention"]
+            key = ("intention", node["id"])
+            suffix = (
+                f" — {record['classification']}" if "classification" in record else ""
+            )
+            entities[key] = f"{node['name']} — intention/{node['type']}{suffix}"
+            for candidate in record.get("reality_candidates", []):
+                candidate_key = ("reality", candidate["id"])
+                entities[candidate_key] = (
+                    f"{candidate['name']} — reality/{candidate['type']}"
+                )
+                identity_edges.append((key, candidate_key, record["classification"]))
+        else:
+            node = record["reality"]
+            key = ("reality", node["id"])
+            entities[key] = f"{node['name']} — reality/{node['type']}"
+    return sorted(entities.items()), identity_edges
+
+
+def render_dag_mermaid(report: Mapping[str, Any]) -> str:
+    """Render a report as safe Mermaid using only synthetic identifiers."""
+
+    entity_items, identity_edges = _record_entities(report)
+    synthetic_ids = {
+        key: f"n{index:04d}" for index, (key, _) in enumerate(entity_items)
+    }
+    lines = ["flowchart LR"]
+    for key, label in entity_items:
+        lines.append(f'  {synthetic_ids[key]}["{_mermaid_label(label)}"]')
+
+    edges: list[tuple[str, str, str]] = []
+    for relationship in report.get("intended_relationships", []):
+        source = ("intention", relationship["source_id"])
+        target = ("intention", relationship["target_id"])
+        if source in synthetic_ids and target in synthetic_ids:
+            edges.append(
+                (
+                    synthetic_ids[source],
+                    synthetic_ids[target],
+                    f"intended {relationship['type']}",
+                )
+            )
+    for relationship in report.get("observed_relationships", []):
+        source = ("reality", relationship["source_id"])
+        target = ("reality", relationship["target_id"])
+        if source in synthetic_ids and target in synthetic_ids:
+            edges.append(
+                (
+                    synthetic_ids[source],
+                    synthetic_ids[target],
+                    f"observed {relationship['type']}",
+                )
+            )
+    for source, target, classification in identity_edges:
+        if source in synthetic_ids and target in synthetic_ids:
+            edges.append(
+                (
+                    synthetic_ids[source],
+                    synthetic_ids[target],
+                    f"identity {classification}",
+                )
+            )
+    for source, target, label in sorted(edges):
+        lines.append(f'  {source} -->|"{_mermaid_label(label)}"| {target}')
+    return "\n".join(lines)
+
+
+def render_dag_human(report: Mapping[str, Any]) -> str:
+    """Render a concise name-first report without exposing DAG serialization."""
+
+    def display_name(node: Mapping[str, Any]) -> str:
+        return _plain_label(node.get("name", "Unnamed node"))
+
+    def source_suffix(source_evidence: Mapping[str, Any] | None) -> str:
+        locations = (source_evidence or {}).get("locations", [])
+        if not locations:
+            return "source unavailable"
+        rendered_locations = []
+        for location in locations:
+            path = _plain_label(location.get("path", "unknown path"), limit=160)
+            line = _plain_label(location.get("definition_line", "?"), limit=12)
+            rendered_locations.append(f"{path}:{line}")
+        return "source " + ", ".join(rendered_locations)
+
+    summary = report["summary"]
+    record_limit = report["limits"]["records"]
+    lines = [
+        f"DAG visualization ({report['view']})",
+        (
+            f"Records: {record_limit['returned_items']}/{record_limit['total_items']}"
+            f"; intended relationships: {summary['intended_relationships']}"
+            f"; observed relationships: {summary['observed_relationships']}"
+        ),
+    ]
+    if record_limit["truncated"]:
+        lines.append("Record output is truncated.")
+
+    intention_names: dict[str, str] = {}
+    reality_names: dict[str, str] = {}
+    audit_ids: dict[tuple[str, str], str] = {}
+    for record in report["records"]:
+        classification = _plain_label(record.get("classification", "not compared"))
+        if record["subject_kind"] in {"intention", "intent"}:
+            node = record["intention"]
+            name = display_name(node)
+            intention_names[node["id"]] = name
+            audit_ids[("Intention", node["id"])] = name
+            label = "Intent" if record["subject_kind"] == "intent" else "Intention"
+            lines.append(
+                f"- {label}: {name} [{_plain_label(node['type'])}] — "
+                f"{classification}"
+            )
+            for candidate in record.get("reality_candidates", []):
+                candidate_name = display_name(candidate)
+                reality_names[candidate["id"]] = candidate_name
+                audit_ids[("Reality", candidate["id"])] = candidate_name
+                lines.append(
+                    f"  - Reality: {candidate_name} "
+                    f"[{_plain_label(candidate['type'])}] — {classification} — "
+                    f"{source_suffix(candidate.get('source_evidence'))}"
+                )
+        else:
+            node = record["reality"]
+            name = display_name(node)
+            reality_names[node["id"]] = name
+            audit_ids[("Reality", node["id"])] = name
+            lines.append(
+                f"- Reality: {name} [{_plain_label(node['type'])}] — "
+                f"{classification} — {source_suffix(record.get('source_evidence'))}"
+            )
+
+    def append_relationships(
+        relationships: Iterable[Mapping[str, Any]],
+        *,
+        heading: str,
+        names: Mapping[str, str],
+        kind: str,
+    ) -> None:
+        for relationship in relationships:
+            source_id = relationship["source_id"]
+            target_id = relationship["target_id"]
+            source_name = names.get(source_id)
+            target_name = names.get(target_id)
+            if source_name is None or target_name is None:
+                audit_ids.setdefault((kind, source_id), "Record omitted by bounds")
+                audit_ids.setdefault((kind, target_id), "Record omitted by bounds")
+                lines.append(
+                    f"- {heading}: endpoint names unavailable within the record bound"
+                )
+                continue
+            relation_type = _plain_label(relationship["type"], limit=40)
+            line = f"- {heading}: {source_name} --{relation_type}--> {target_name}"
+            if relationship.get("description"):
+                line += f" — {_plain_label(relationship['description'])}"
+            lines.append(line)
+
+    append_relationships(
+        report.get("intended_relationships", []),
+        heading="Intended",
+        names=intention_names,
+        kind="Intention",
+    )
+    append_relationships(
+        report.get("observed_relationships", []),
+        heading="Observed",
+        names=reality_names,
+        kind="Reality",
+    )
+
+    lines.extend(["", "Audit IDs"])
+    for (kind, canonical_id), name in sorted(audit_ids.items()):
+        lines.append(f"- {kind}: {_plain_label(name)} — {canonical_id}")
+    return "\n".join(lines)
+
+
+def render_dag(report: Mapping[str, Any], output_format: str) -> str:
+    """Render one report through the shared CLI/MCP format contract."""
+
+    if not isinstance(output_format, str):
+        raise TypeError("output_format must be a string")
+    normalized = output_format.casefold()
+    if normalized == "json":
+        return json.dumps(report, indent=2)
+    if normalized == "human":
+        return render_dag_human(report)
+    if normalized == "mermaid":
+        return render_dag_mermaid(report)
+    raise ValueError(f"Unsupported output format: {output_format}")

--- a/src/aio_agentic_sdlc/mcp_server.py
+++ b/src/aio_agentic_sdlc/mcp_server.py
@@ -18,6 +18,7 @@ from .core import (
 )
 from .dag_manager import DAGManager
 from .dag_models import Node, NodeType
+from .dag_visualization import DAGVisualizationEngine, render_dag
 from .drift_triage import DriftTriageEngine, TriageDecisionSet
 from .intent_ir import IntentIR
 from .intent_store import create_intent_node_file, update_intent_file
@@ -382,6 +383,63 @@ def reconcile_dags(
         return json.dumps(report, indent=2)
     except Exception as e:
         return f"Error reconciling DAGs: {str(e)}"
+
+
+@mcp.tool()
+def visualize_dag(
+    project_path: Annotated[
+        str, Field(description="Absolute path to the project directory")
+    ] = ".",
+    view: Annotated[
+        str,
+        Field(description="DAG view: intention, reality, or comparison"),
+    ] = "comparison",
+    focus_node_id: Annotated[
+        str,
+        Field(description="Optional canonical node GUID for a focused neighborhood"),
+    ] = "",
+    depth: Annotated[
+        int,
+        Field(ge=0, description="Incoming and outgoing neighborhood depth"),
+    ] = 1,
+    max_items: Annotated[
+        int,
+        Field(ge=1, description="Maximum records; totals remain complete"),
+    ] = 100,
+    max_edges: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum intended and observed relationships per collection",
+        ),
+    ] = 200,
+    max_candidates: Annotated[
+        int,
+        Field(
+            ge=1,
+            description="Maximum candidates and nested source locations per record",
+        ),
+    ] = 20,
+    output_format: Annotated[
+        str,
+        Field(description="Output format: human, mermaid, or json"),
+    ] = "human",
+) -> str:
+    """Render canonical DAG evidence without mutating project state."""
+
+    try:
+        engine = DAGVisualizationEngine.from_project(project_path)
+        report = engine.build_report(
+            view=view,
+            focus_node_id=focus_node_id or None,
+            depth=depth,
+            max_items=max_items,
+            max_edges=max_edges,
+            max_candidates=max_candidates,
+        )
+        return render_dag(report, output_format)
+    except Exception as e:
+        return f"Error visualizing DAGs: {str(e)}"
 
 
 @mcp.tool()

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -91,6 +91,26 @@ def test_codex_skill_routes_intent_ir_through_protected_tools() -> None:
     assert "do not patch DAG files" in cartographer
 
 
+def test_codex_skill_routes_visual_review_before_mapping_approval() -> None:
+    skill_root = PLUGIN_ROOT / "skills" / "manage-sdlc"
+    tools = (skill_root / "references" / "tools.md").read_text(encoding="utf-8")
+    cartographer = (skill_root / "references" / "roles" / "cartographer.md").read_text(
+        encoding="utf-8"
+    )
+    manifest = json.loads(
+        (PLUGIN_ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+
+    assert "visualize_dag" in tools
+    assert "dag-tool visualize" in tools
+    assert cartographer.index("visualize_dag") < cartographer.index("approve_mapping")
+    assert any(
+        "visual" in prompt.casefold()
+        for prompt in manifest["interface"]["defaultPrompt"]
+    )
+    assert (ROOT / "doc" / "dag-visualization.md").is_file()
+
+
 def test_project_scoped_codex_agents_map_every_sdlc_role() -> None:
     agent_dir = ROOT / ".codex" / "agents"
     configs = {

--- a/tests/test_dag_cli.py
+++ b/tests/test_dag_cli.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 from aio_agentic_sdlc.dag_cli import cli
 from aio_agentic_sdlc.dag_manager import DAGManager
 from aio_agentic_sdlc.dag_models import Edge, EdgeType, Metadata, Node, NodeType
-from aio_agentic_sdlc.workspace import INTENTION_DAG_FILE
+from aio_agentic_sdlc.workspace import INTENTION_DAG_FILE, REALITY_DAG_FILE
 
 
 @pytest.fixture
@@ -42,6 +42,36 @@ def test_cli_validate(sample_dag_file):
     result = runner.invoke(cli, ["validate", "--file", sample_dag_file])
     assert result.exit_code == 0
     assert "DAG is valid." in result.output
+
+
+def test_cli_validate_rejects_duplicate_raw_node_ids(tmp_path):
+    duplicate_id = "00000000-0000-0000-0000-000000000001"
+    dag_file = tmp_path / "duplicate.yaml"
+    dag_file.write_text(
+        "\n".join(
+            [
+                "metadata:",
+                "  name: Duplicate",
+                "  version: '1.0'",
+                "nodes:",
+                f"- id: {duplicate_id}",
+                "  type: component",
+                "  name: First",
+                f"- id: {duplicate_id}",
+                "  type: component",
+                "  name: Last",
+                "edges: []",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli, ["validate", "--file", str(dag_file)])
+
+    assert result.exit_code == 1
+    assert "Duplicate node ID" in result.output
+    assert "Last" not in result.output
 
 
 def test_cli_node_add(sample_dag_file):
@@ -219,6 +249,117 @@ def test_cli_reconcile_returns_bounded_read_only_report(sample_dag_file, tmp_pat
     }
     assert (tmp_path / "dag.yaml").read_bytes() == before_intention
     assert reality_file.read_bytes() == before_reality
+
+
+def test_cli_visualize_supports_all_formats_and_never_mutates_state(tmp_path):
+    first = "00000000-0000-0000-0000-000000000001"
+    second = "00000000-0000-0000-0000-000000000002"
+    metadata = Metadata(name="Visualization", version="1.0")
+    nodes = [
+        Node(id=first, type=NodeType.COMPONENT, name="First"),
+        Node(id=second, type=NodeType.COMPONENT, name="Second"),
+    ]
+    edges = [Edge(source=first, target=second, type=EdgeType.CALLS)]
+    intention_path = tmp_path / INTENTION_DAG_FILE
+    reality_path = tmp_path / REALITY_DAG_FILE
+    intention_path.parent.mkdir(parents=True)
+    DAGManager(metadata, nodes, edges).save(str(intention_path))
+    DAGManager(metadata, nodes, edges).save(str(reality_path))
+    before = (intention_path.read_bytes(), reality_path.read_bytes())
+    runner = CliRunner()
+
+    json_result = runner.invoke(
+        cli,
+        [
+            "visualize",
+            "--project-path",
+            str(tmp_path),
+            "--view",
+            "comparison",
+            "--max-items",
+            "1",
+            "--max-edges",
+            "1",
+            "--max-candidates",
+            "1",
+            "--format",
+            "json",
+        ],
+    )
+    human_result = runner.invoke(
+        cli,
+        [
+            "visualize",
+            "--project-path",
+            str(tmp_path),
+            "--view",
+            "intention",
+            "--format",
+            "human",
+        ],
+    )
+    mermaid_result = runner.invoke(
+        cli,
+        [
+            "visualize",
+            "--project-path",
+            str(tmp_path),
+            "--view",
+            "reality",
+            "--format",
+            "mermaid",
+        ],
+    )
+
+    assert json_result.exit_code == 0
+    report = json.loads(json_result.output)
+    assert report["view"] == "comparison"
+    assert report["limits"]["records"]["truncated"] is True
+    assert report["source_discovery"]["state"] == "unavailable"
+    assert human_result.exit_code == 0
+    assert human_result.output.startswith("DAG visualization (intention)")
+    assert mermaid_result.exit_code == 0
+    assert mermaid_result.output.startswith("flowchart LR")
+    assert (intention_path.read_bytes(), reality_path.read_bytes()) == before
+
+
+def test_cli_visualize_rejects_unknown_focus_and_invalid_limits(tmp_path):
+    metadata = Metadata(name="Visualization", version="1.0")
+    workspace = tmp_path / INTENTION_DAG_FILE
+    workspace.parent.mkdir(parents=True)
+    DAGManager(metadata, [], []).save(str(workspace))
+    DAGManager(metadata, [], []).save(str(tmp_path / REALITY_DAG_FILE))
+    runner = CliRunner()
+
+    unknown = runner.invoke(
+        cli,
+        [
+            "visualize",
+            "--project-path",
+            str(tmp_path),
+            "--view",
+            "comparison",
+            "--focus-node",
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        ],
+    )
+    invalid_limit = runner.invoke(
+        cli,
+        [
+            "visualize",
+            "--project-path",
+            str(tmp_path),
+            "--view",
+            "comparison",
+            "--max-edges",
+            "0",
+        ],
+    )
+
+    assert unknown.exit_code == 1
+    assert "Unknown focus node" in unknown.output
+    assert invalid_limit.exit_code == 2
+    assert "0 is not in the range x>=1" in invalid_limit.output
 
 
 def test_cli_reconcile_can_write_a_reproducible_report_artifact(

--- a/tests/test_dag_visualization.py
+++ b/tests/test_dag_visualization.py
@@ -1,0 +1,442 @@
+import json
+from copy import deepcopy
+
+import pytest
+
+from aio_agentic_sdlc.dag_manager import DAGManager
+from aio_agentic_sdlc.dag_models import Edge, EdgeType, Metadata, Node, NodeType
+from aio_agentic_sdlc.dag_visualization import (
+    DAGVisualizationEngine,
+    render_dag_human,
+    render_dag_mermaid,
+)
+from aio_agentic_sdlc.source_locations import SourceLocation
+from aio_agentic_sdlc.workspace import INTENTION_DAG_FILE, REALITY_DAG_FILE
+
+
+def _node(node_id: str, name: str) -> Node:
+    return Node(id=node_id, type=NodeType.COMPONENT, name=name)
+
+
+def _dag(nodes, edges=(), *, name="Test DAG") -> DAGManager:
+    return DAGManager(Metadata(name=name, version="1.0"), list(nodes), list(edges))
+
+
+def _engine(intention, reality, source_locations=None):
+    return DAGVisualizationEngine(
+        intention,
+        reality,
+        source_locations=source_locations,
+    )
+
+
+def test_reports_are_deterministic_across_input_order_guid_case_and_views():
+    first = "aaaaaaaa-0000-0000-0000-000000000001"
+    second = "BBBBBBBB-0000-0000-0000-000000000002"
+    nodes = [_node(first, "First"), _node(second, "Second")]
+    edges = [Edge(source=first, target=second, type=EdgeType.CALLS)]
+    forward_engine = _engine(_dag(nodes, edges), _dag(nodes, edges))
+
+    shuffled_nodes = [deepcopy(nodes[1]), deepcopy(nodes[0])]
+    shuffled_nodes[0].id = second.lower()
+    shuffled_nodes[1].id = first.upper()
+    shuffled_edges = [
+        Edge(source=first.upper(), target=second.lower(), type=EdgeType.CALLS)
+    ]
+    reverse_engine = _engine(
+        _dag(shuffled_nodes, shuffled_edges),
+        _dag(shuffled_nodes, shuffled_edges),
+    )
+
+    for view in ("intention", "reality", "comparison"):
+        forward = forward_engine.build_report(view=view)
+        reverse = reverse_engine.build_report(view=view)
+        assert json.dumps(forward, sort_keys=True) == json.dumps(
+            reverse, sort_keys=True
+        )
+        assert forward["view"] == view
+    assert [
+        item["canonical_id"]
+        for item in forward_engine.build_report(view="intention")["records"]
+    ] == [first, second.lower()]
+
+
+def test_focus_uses_incoming_and_outgoing_edges_at_each_depth():
+    ids = [f"00000000-0000-0000-0000-{number:012d}" for number in range(1, 5)]
+    nodes = [_node(node_id, f"Node {index}") for index, node_id in enumerate(ids)]
+    edges = [
+        Edge(source=ids[0], target=ids[1], type=EdgeType.CALLS),
+        Edge(source=ids[2], target=ids[1], type=EdgeType.READS),
+        Edge(source=ids[2], target=ids[3], type=EdgeType.WRITES),
+    ]
+    engine = _engine(_dag(nodes, edges), _dag(nodes, edges))
+
+    at_zero = engine.build_report(view="intention", focus_node_id=ids[1], depth=0)
+    at_one = engine.build_report(view="intention", focus_node_id=ids[1], depth=1)
+    at_two = engine.build_report(view="intention", focus_node_id=ids[1], depth=2)
+
+    assert [record["canonical_id"] for record in at_zero["records"]] == [ids[1]]
+    assert [record["canonical_id"] for record in at_one["records"]] == [
+        ids[1],
+        ids[0],
+        ids[2],
+    ]
+    assert [record["canonical_id"] for record in at_two["records"]] == [
+        ids[1],
+        ids[0],
+        ids[2],
+        ids[3],
+    ]
+    with pytest.raises(ValueError, match="Unknown focus node"):
+        engine.build_report(
+            view="intention",
+            focus_node_id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+        )
+
+
+def test_comparison_has_all_classifications_relations_and_exact_source_evidence():
+    ids = [f"00000000-0000-0000-0000-{number:012d}" for number in range(1, 5)]
+    intention = _dag(
+        [
+            _node(ids[0], "Confirmed"),
+            _node(ids[1], "Candidate"),
+            _node(ids[2], "Ambiguous"),
+            _node(ids[3], "Missing"),
+        ],
+        [Edge(source=ids[0], target=ids[1], type=EdgeType.CALLS)],
+    )
+    candidate_id = "00000000-0000-0000-0000-000000000012"
+    reality = _dag(
+        [
+            _node(ids[0], "Confirmed"),
+            _node(candidate_id, "Candidate"),
+            _node("00000000-0000-0000-0000-000000000013", "Ambiguous"),
+            _node("00000000-0000-0000-0000-000000000014", "Ambiguous"),
+        ],
+        [Edge(source=ids[0], target=candidate_id, type=EdgeType.CALLS)],
+    )
+    location = SourceLocation(
+        path="src/candidate.py",
+        symbol_kind="class",
+        symbol_name="Candidate",
+        definition_line=10,
+        marker_line=9,
+        source_sha256="a" * 64,
+    )
+
+    report = _engine(
+        intention,
+        reality,
+        {candidate_id: [location]},
+    ).build_report()
+
+    classifications = {
+        record["classification"]
+        for record in report["records"]
+        if record["subject_kind"] == "intent"
+    }
+    assert classifications == {"confirmed", "candidate", "ambiguous", "unmapped"}
+    assert report["summary"]["classifications"] == {
+        "confirmed": 1,
+        "candidate": 1,
+        "ambiguous": 1,
+        "unmapped": 1,
+    }
+    assert report["intended_relationships"][0]["target_id"] == ids[1]
+    assert report["observed_relationships"][0]["target_id"] == candidate_id
+    candidate = next(
+        record
+        for record in report["records"]
+        if record["classification"] == "candidate"
+    )
+    assert candidate["reality_candidates"][0]["source_evidence"]["locations"] == [
+        location.as_dict()
+    ]
+    assert candidate["evidence_state"]["behavioral_verification"] == "unavailable"
+
+
+def test_all_collections_are_bounded_while_totals_remain_complete():
+    intent_id = "00000000-0000-0000-0000-000000000001"
+    reality_ids = [f"00000000-0000-0000-0000-{number:012d}" for number in range(10, 14)]
+    intention = _dag([_node(intent_id, "Duplicate")])
+    reality_nodes = [_node(node_id, "Duplicate") for node_id in reality_ids]
+    reality_edges = [
+        Edge(
+            source=reality_ids[index],
+            target=reality_ids[index + 1],
+            type=EdgeType.READS,
+        )
+        for index in range(3)
+    ]
+    locations = {
+        node_id: [
+            SourceLocation(
+                path=f"src/{index}.py",
+                symbol_kind="class",
+                symbol_name="Duplicate",
+                definition_line=index + 1,
+                marker_line=index + 1,
+                source_sha256=str(index) * 64,
+            )
+            for index in range(3)
+        ]
+        for node_id in reality_ids
+    }
+
+    report = _engine(
+        intention,
+        _dag(reality_nodes, reality_edges),
+        locations,
+    ).build_report(max_items=1, max_edges=1, max_candidates=1)
+
+    assert report["limits"]["records"] == {
+        "max_items": 1,
+        "total_items": 5,
+        "returned_items": 1,
+        "truncated": True,
+    }
+    assert report["limits"]["observed_relationships"] == {
+        "max_edges": 1,
+        "total_edges": 3,
+        "returned_edges": 1,
+        "truncated": True,
+    }
+    record = report["records"][0]
+    assert record["candidate_limit"]["total_candidates"] == 4
+    assert len(record["reality_candidates"]) == 1
+    source_limit = record["reality_candidates"][0]["source_evidence"]["limit"]
+    assert source_limit["total_items"] == 3
+    assert source_limit["returned_items"] == 1
+    assert source_limit["truncated"] is True
+
+
+def test_mermaid_uses_synthetic_ids_and_escapes_bounded_malicious_labels():
+    node_id = "00000000-0000-0000-0000-000000000001"
+    malicious = (
+        'bad"]\nclick n0 "javascript:alert(1)"\n%%{init: {}}%%<script>' + "x" * 300
+    )
+    report = _engine(_dag([_node(node_id, malicious)]), _dag([])).build_report(
+        view="intention"
+    )
+
+    rendered = render_dag_mermaid(report)
+
+    assert 'n0000["' in rendered
+    assert node_id not in rendered
+    assert "<script>" not in rendered
+    assert "%%{" not in rendered
+    assert "\nclick " not in rendered
+    assert "&lt;script&gt;" in rendered
+    assert len(rendered) < 500
+    assert "DAG visualization" in render_dag_human(report)
+
+
+def test_invalid_dags_arguments_and_read_only_postcondition(tmp_path):
+    node_id = "00000000-0000-0000-0000-000000000001"
+    missing_id = "00000000-0000-0000-0000-000000000002"
+    invalid = _dag(
+        [_node(node_id, "Only")],
+        [Edge(source=node_id, target=missing_id, type=EdgeType.CALLS)],
+    )
+    with pytest.raises(ValueError, match="does not exist"):
+        _engine(invalid, _dag([]))
+
+    intention_path = tmp_path / "intention.yaml"
+    reality_path = tmp_path / "reality.yaml"
+    _dag([_node(node_id, "Only")]).save(str(intention_path))
+    _dag([]).save(str(reality_path))
+    before = (intention_path.read_bytes(), reality_path.read_bytes())
+    engine = _engine(
+        DAGManager.load(str(intention_path)),
+        DAGManager.load(str(reality_path)),
+    )
+    engine.build_report(view="comparison")
+    assert (intention_path.read_bytes(), reality_path.read_bytes()) == before
+
+    with pytest.raises(ValueError, match="Unsupported view"):
+        engine.build_report(view="raw")
+    with pytest.raises(ValueError, match="depth must be at least 0"):
+        engine.build_report(depth=-1)
+    with pytest.raises(ValueError, match="max_edges must be at least 1"):
+        engine.build_report(max_edges=0)
+
+
+def test_project_source_discovery_requires_an_exact_fresh_reality_match(
+    tmp_path, monkeypatch
+):
+    node_id = "00000000-0000-0000-0000-000000000001"
+    metadata = Metadata(name="Fresh", version="1.0")
+    canonical = _dag([_node(node_id, "Fresh")], name="Fresh")
+    intention_path = tmp_path / INTENTION_DAG_FILE
+    reality_path = tmp_path / REALITY_DAG_FILE
+    intention_path.parent.mkdir(parents=True)
+    canonical.save(str(intention_path))
+    canonical.save(str(reality_path))
+    location = SourceLocation(
+        path="src/fresh.py",
+        symbol_kind="class",
+        symbol_name="Fresh",
+        definition_line=2,
+        marker_line=1,
+        source_sha256="f" * 64,
+    )
+
+    class MatchingGenerator:
+        def __init__(self, root_dir, system_name):
+            self.source_locations = {node_id: [location]}
+
+        def generate(self):
+            return DAGManager(metadata, [_node(node_id, "Fresh")], [])
+
+    monkeypatch.setattr(
+        "aio_agentic_sdlc.dag_visualization.RealityDAGGenerator",
+        MatchingGenerator,
+    )
+    matching = DAGVisualizationEngine.from_project(tmp_path).build_report(
+        view="reality"
+    )
+
+    assert matching["source_discovery"]["state"] == "available"
+    assert matching["records"][0]["source_evidence"]["locations"] == [
+        location.as_dict()
+    ]
+
+    class StaleGenerator(MatchingGenerator):
+        def generate(self):
+            return DAGManager(metadata, [], [])
+
+    monkeypatch.setattr(
+        "aio_agentic_sdlc.dag_visualization.RealityDAGGenerator",
+        StaleGenerator,
+    )
+    stale = DAGVisualizationEngine.from_project(tmp_path).build_report(view="reality")
+
+    assert stale["source_discovery"]["state"] == "unavailable"
+    assert stale["records"][0]["source_evidence"]["state"] == "unavailable"
+    assert stale["records"][0]["source_evidence"]["locations"] == []
+
+
+def test_human_renderer_puts_names_and_sources_before_final_audit_ids():
+    service_id = "00000000-0000-0000-0000-000000000001"
+    worker_id = "00000000-0000-0000-0000-000000000002"
+    edge = Edge(source=service_id, target=worker_id, type=EdgeType.CALLS)
+    location = SourceLocation(
+        path="src/service.py",
+        symbol_kind="class",
+        symbol_name="Service",
+        definition_line=10,
+        marker_line=9,
+        source_sha256="a" * 64,
+    )
+    report = _engine(
+        _dag([_node(service_id, "Service"), _node(worker_id, "Worker")], [edge]),
+        _dag([_node(service_id, "Service"), _node(worker_id, "Worker")], [edge]),
+        {service_id: [location]},
+    ).build_report()
+
+    rendered = render_dag_human(report)
+    evidence, audit = rendered.split("\nAudit IDs\n", maxsplit=1)
+
+    assert "Intent: Service [component] — confirmed" in evidence
+    assert (
+        "Reality: Service [component] — confirmed — source src/service.py:10"
+        in evidence
+    )
+    assert "Intended: Service --calls--> Worker" in evidence
+    assert "Observed: Service --calls--> Worker" in evidence
+    assert service_id not in evidence
+    assert worker_id not in evidence
+    assert service_id in audit
+    assert worker_id in audit
+
+
+def test_reality_only_focus_seeds_all_contested_intention_candidates_at_depth_zero():
+    intent_ids = [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+    ]
+    focus_id = "00000000-0000-0000-0000-000000000010"
+    report = _engine(
+        _dag([_node(intent_id, "Shared") for intent_id in intent_ids]),
+        _dag([_node(focus_id, "Shared")]),
+    ).build_report(
+        view="comparison",
+        focus_node_id=focus_id,
+        depth=0,
+    )
+
+    intent_records = [
+        record for record in report["records"] if record["subject_kind"] == "intent"
+    ]
+    assert [record["canonical_id"] for record in intent_records] == intent_ids
+    assert {record["classification"] for record in intent_records} == {"ambiguous"}
+    assert all(
+        [candidate["id"] for candidate in record["reality_candidates"]] == [focus_id]
+        for record in intent_records
+    )
+
+
+def test_visualization_canonicalizes_mixed_case_edge_endpoints_before_validation():
+    source_id = "aaaaaaaa-0000-0000-0000-000000000001"
+    target_id = "bbbbbbbb-0000-0000-0000-000000000002"
+    manager = _dag(
+        [_node(source_id, "Source"), _node(target_id, "Target")],
+        [
+            Edge(
+                source=source_id.upper(),
+                target=target_id.upper(),
+                type=EdgeType.CALLS,
+            )
+        ],
+    )
+
+    report = _engine(manager, _dag([])).build_report(view="intention")
+
+    assert report["intended_relationships"] == [
+        {"source_id": source_id, "target_id": target_id, "type": "calls"}
+    ]
+
+
+def test_source_location_strings_are_bounded_with_field_truncation_metadata():
+    node_id = "00000000-0000-0000-0000-000000000001"
+    locations = [
+        SourceLocation(
+            path="p" * 400,
+            symbol_kind="k" * 400,
+            symbol_name="n" * 400,
+            definition_line=1,
+            marker_line=1,
+            source_sha256="s" * 400,
+        ),
+        SourceLocation(
+            path="second.py",
+            symbol_kind="class",
+            symbol_name="Second",
+            definition_line=2,
+            marker_line=2,
+            source_sha256="a" * 64,
+        ),
+    ]
+    report = _engine(
+        _dag([]),
+        _dag([_node(node_id, "Reality")]),
+        {node_id: locations},
+    ).build_report(view="reality", max_candidates=1)
+
+    evidence = report["records"][0]["source_evidence"]
+    bounded = evidence["locations"][0]
+    assert all(
+        len(bounded[field]) <= 200
+        for field in ("path", "symbol_kind", "symbol_name", "source_sha256")
+    )
+    assert evidence["location_truncation"] == [
+        {
+            "path": True,
+            "symbol_kind": True,
+            "symbol_name": True,
+            "source_sha256": True,
+        }
+    ]
+    assert evidence["limit"]["total_items"] == 2
+    assert evidence["limit"]["returned_items"] == 1
+    assert evidence["limit"]["truncated"] is True

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,14 +2,18 @@ import json
 import os
 from pathlib import Path
 
+from click.testing import CliRunner
+
+from aio_agentic_sdlc.dag_cli import cli
 from aio_agentic_sdlc.dag_manager import DAGManager
-from aio_agentic_sdlc.dag_models import Metadata, Node, NodeType
+from aio_agentic_sdlc.dag_models import Edge, EdgeType, Metadata, Node, NodeType
 from aio_agentic_sdlc.mcp_server import (
     approve_mapping,
     generate_document,
     reconcile_dags,
     review_mapping,
     triage_reconciliation_drift,
+    visualize_dag,
 )
 from aio_agentic_sdlc.workspace import (
     CHANGES_DIR,
@@ -137,6 +141,73 @@ def test_mcp_triage_reconciliation_drift_withholds_unapproved_intent(tmp_path):
     assert result["summary"]["obsolete_or_unapproved_intent"] == 1
     assert result["summary"]["actionable_implementation"] == 0
     assert result["items"][0]["decision_source"] == "approval_gate"
+
+
+def test_mcp_visualize_matches_cli_and_never_mutates_state(tmp_path):
+    first = "00000000-0000-0000-0000-000000000001"
+    second = "00000000-0000-0000-0000-000000000002"
+    metadata = Metadata(name="Visualization", version="1.0")
+    nodes = [
+        Node(id=first, type=NodeType.COMPONENT, name="First"),
+        Node(id=second, type=NodeType.COMPONENT, name="Second"),
+    ]
+    edges = [Edge(source=first, target=second, type=EdgeType.CALLS)]
+    intention_path = tmp_path / INTENTION_DAG_FILE
+    reality_path = tmp_path / REALITY_DAG_FILE
+    intention_path.parent.mkdir(parents=True)
+    DAGManager(metadata, nodes, edges).save(str(intention_path))
+    DAGManager(metadata, nodes, edges).save(str(reality_path))
+    before = (intention_path.read_bytes(), reality_path.read_bytes())
+
+    cli_result = CliRunner().invoke(
+        cli,
+        [
+            "visualize",
+            "--project-path",
+            str(tmp_path),
+            "--view",
+            "comparison",
+            "--depth",
+            "0",
+            "--max-items",
+            "1",
+            "--max-edges",
+            "1",
+            "--max-candidates",
+            "1",
+            "--format",
+            "json",
+        ],
+    )
+    mcp_result = visualize_dag(
+        project_path=str(tmp_path),
+        view="comparison",
+        depth=0,
+        max_items=1,
+        max_edges=1,
+        max_candidates=1,
+        output_format="json",
+    )
+
+    assert cli_result.exit_code == 0
+    assert json.loads(mcp_result) == json.loads(cli_result.output)
+    assert (intention_path.read_bytes(), reality_path.read_bytes()) == before
+
+
+def test_mcp_visualize_reports_argument_errors(tmp_path):
+    metadata = Metadata(name="Visualization", version="1.0")
+    intention_path = tmp_path / INTENTION_DAG_FILE
+    intention_path.parent.mkdir(parents=True)
+    DAGManager(metadata, [], []).save(str(intention_path))
+    DAGManager(metadata, [], []).save(str(tmp_path / REALITY_DAG_FILE))
+
+    assert "Unsupported view" in visualize_dag(project_path=str(tmp_path), view="raw")
+    assert "max_edges must be at least 1" in visualize_dag(
+        project_path=str(tmp_path), max_edges=0
+    )
+    assert "Unsupported output format" in visualize_dag(
+        project_path=str(tmp_path), output_format="yaml"
+    )
 
 
 def test_mcp_mapping_review_and_approval_use_source_bound_evidence(tmp_path):


### PR DESCRIPTION
## Summary
- add deterministic, bounded Intention/Reality/comparison views in human, Mermaid, and JSON formats
- expose equivalent dag-tool visualize and visualize_dag MCP operations with fail-closed source provenance
- make human review name/relationship/source-first with GUIDs isolated to a final audit section
- document and dogfood the visualization-before-mapping workflow

## QA
- formal sdlc_qa feedback loop: initial FAIL found 4 functional/security defects; all corrected; final PASS
- 305 warning-strict tests passed
- 47 focused visualization/CLI/MCP/plugin tests and 27 CLI/MCP parity cases passed
- Ruff, Black, Markdownlint, UV lock/build, plugin/skill validators passed
- invalid DAG, duplicate identity, mixed-case GUID, malicious Mermaid, stale source, bounds, and read-only adversarial checks passed
- Reality DAG and self-dogfood report reproduced byte-for-byte

## Evidence
- Reality SHA-256: f2bb260e01875ef010bb4588011558db0728a8f32ca3f6c225e77487c265d739
- self-dogfood report SHA-256: 7638104ab9f3930518da9030ce74e5a69185921f1651fcea58308344602113f2
- no new runtime dependency